### PR TITLE
Feature/#67/dto 수정, 순환 참조 에러 잡기

### DIFF
--- a/src/main/java/mokindang/jubging/project_backend/controller/authentication/AuthenticationController.java
+++ b/src/main/java/mokindang/jubging/project_backend/controller/authentication/AuthenticationController.java
@@ -6,8 +6,8 @@ import mokindang.jubging.project_backend.domain.member.LoginState;
 import mokindang.jubging.project_backend.service.authentication.AuthenticationService;
 import mokindang.jubging.project_backend.service.member.request.RefreshTokenRequest;
 import mokindang.jubging.project_backend.service.member.response.JwtResponse;
-import mokindang.jubging.project_backend.service.member.response.LoginResponseDto;
-import mokindang.jubging.project_backend.service.member.response.LoginStateResponse;
+import mokindang.jubging.project_backend.service.member.response.KakaoLoginResponse;
+import mokindang.jubging.project_backend.service.member.response.LoginResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -22,18 +22,18 @@ public class AuthenticationController {
     private final AuthenticationService authenticationService;
 
     @GetMapping("/api/member/join")
-    public ResponseEntity<LoginResponseDto> kakaoCallback(@RequestParam String code) {
-        LoginStateResponse loginStateResponse = authenticationService.login(code);
-        LoginResponseDto loginResponseDto = new LoginResponseDto(loginStateResponse.getAlias());
+    public ResponseEntity<LoginResponse> kakaoCallback(@RequestParam String code) {
+        KakaoLoginResponse kakaoLoginResponse = authenticationService.login(code);
+        LoginResponse loginResponse = new LoginResponse(kakaoLoginResponse.getAlias());
 
-        if (loginStateResponse.getLoginState() == LoginState.JOIN) {
+        if (kakaoLoginResponse.getLoginState() == LoginState.JOIN) {
             return ResponseEntity.status(HttpStatus.CREATED)
-                    .header(AUTHORIZATION_HEADER, loginStateResponse.getAccessToken(), loginStateResponse.getRefreshToken())
-                    .body(loginResponseDto);
+                    .header(AUTHORIZATION_HEADER, kakaoLoginResponse.getAccessToken(), kakaoLoginResponse.getRefreshToken())
+                    .body(loginResponse);
         }
         return ResponseEntity.ok()
-                .header(AUTHORIZATION_HEADER, loginStateResponse.getAccessToken(), loginStateResponse.getRefreshToken())
-                .body(loginResponseDto);
+                .header(AUTHORIZATION_HEADER, kakaoLoginResponse.getAccessToken(), kakaoLoginResponse.getRefreshToken())
+                .body(loginResponse);
     }
 
     @PostMapping("/api/member/reissueToken")

--- a/src/main/java/mokindang/jubging/project_backend/controller/authentication/AuthenticationController.java
+++ b/src/main/java/mokindang/jubging/project_backend/controller/authentication/AuthenticationController.java
@@ -24,8 +24,7 @@ public class AuthenticationController {
     @GetMapping("/api/member/join")
     public ResponseEntity<LoginResponseDto> kakaoCallback(@RequestParam String code) {
         LoginStateResponse loginStateResponse = authenticationService.login(code);
-        LoginResponseDto loginResponseDto =
-                new LoginResponseDto(loginStateResponse.getAccessToken(), loginStateResponse.getRefreshToken(), loginStateResponse.getAlias());
+        LoginResponseDto loginResponseDto = new LoginResponseDto(loginStateResponse.getAlias());
 
         if (loginStateResponse.getLoginState() == LoginState.JOIN) {
             return ResponseEntity.status(HttpStatus.CREATED)

--- a/src/main/java/mokindang/jubging/project_backend/service/member/response/KakaoApiMemberResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/member/response/KakaoApiMemberResponse.java
@@ -1,14 +1,23 @@
 package mokindang.jubging.project_backend.service.member.response;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public class KakaoApiMemberResponse {
-    private final String accessToken;
-    private final String refreshToken;
+
+    @JsonIgnore
+    private final String kakaoAccessToken;
+
+    @JsonIgnore
+    private final String kakaoRefreshToken;
+
+    @JsonIgnore
     private final String alias;
+
+    @JsonIgnore
     private final String email;
 }

--- a/src/main/java/mokindang/jubging/project_backend/service/member/response/KakaoLoginResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/member/response/KakaoLoginResponse.java
@@ -7,7 +7,7 @@ import mokindang.jubging.project_backend.domain.member.LoginState;
 
 @Getter
 @RequiredArgsConstructor
-public class LoginStateResponse {
+public class KakaoLoginResponse {
 
     @JsonIgnore
     private final String accessToken;
@@ -15,9 +15,7 @@ public class LoginStateResponse {
     @JsonIgnore
     private final String refreshToken;
 
-    @JsonIgnore
     private final String alias;
 
-    @JsonIgnore
     private final LoginState loginState;
 }

--- a/src/main/java/mokindang/jubging/project_backend/service/member/response/LoginResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/member/response/LoginResponse.java
@@ -5,11 +5,11 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class LoginResponseDto {
+public class LoginResponse {
 
     private String alias;
 
-    public LoginResponseDto(String alias) {
+    public LoginResponse(String alias) {
         this.alias = alias;
     }
 }

--- a/src/main/java/mokindang/jubging/project_backend/service/member/response/LoginResponseDto.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/member/response/LoginResponseDto.java
@@ -1,18 +1,15 @@
 package mokindang.jubging.project_backend.service.member.response;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor
 public class LoginResponseDto {
 
-    @JsonIgnore
-    private final String accessToken;
+    private String alias;
 
-    @JsonIgnore
-    private final String refreshToken;
-
-    private final String alias;
+    public LoginResponseDto(String alias) {
+        this.alias = alias;
+    }
 }

--- a/src/main/java/mokindang/jubging/project_backend/service/member/response/LoginStateResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/member/response/LoginStateResponse.java
@@ -1,5 +1,6 @@
 package mokindang.jubging.project_backend.service.member.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import mokindang.jubging.project_backend.domain.member.LoginState;
@@ -8,8 +9,15 @@ import mokindang.jubging.project_backend.domain.member.LoginState;
 @RequiredArgsConstructor
 public class LoginStateResponse {
 
+    @JsonIgnore
     private final String accessToken;
+
+    @JsonIgnore
     private final String refreshToken;
+
+    @JsonIgnore
     private final String alias;
+
+    @JsonIgnore
     private final LoginState loginState;
 }

--- a/src/main/java/mokindang/jubging/project_backend/web/interceptor/LoginCheckInterceptor.java
+++ b/src/main/java/mokindang/jubging/project_backend/web/interceptor/LoginCheckInterceptor.java
@@ -21,7 +21,7 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
             tokenManager.validateToken(authorizationHeader);
         } catch (final RuntimeException e) {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.sendRedirect("/");
+            response.sendRedirect("/index.html");
         }
         return true;
     }

--- a/src/test/java/mokindang/jubging/project_backend/controller/authentication/AuthenticationControllerTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/controller/authentication/AuthenticationControllerTest.java
@@ -6,7 +6,7 @@ import mokindang.jubging.project_backend.domain.member.LoginState;
 import mokindang.jubging.project_backend.service.authentication.AuthenticationService;
 import mokindang.jubging.project_backend.service.member.request.RefreshTokenRequest;
 import mokindang.jubging.project_backend.service.member.response.JwtResponse;
-import mokindang.jubging.project_backend.service.member.response.LoginStateResponse;
+import mokindang.jubging.project_backend.service.member.response.KakaoLoginResponse;
 import mokindang.jubging.project_backend.web.jwt.TokenManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,9 +47,9 @@ class AuthenticationControllerTest {
     @DisplayName("회원가입 시 HTTP 상태코드는 201(CREATED)이며 Alias를 JSON으로 반환한다. Access Token 과 Refresh Token 은 Authorization 헤더에 담아 반환한다.")
     void joinAndState201() throws Exception{
         //given
-        LoginStateResponse loginStateResponse = new LoginStateResponse("Test Access Token", "Test Refresh Token", "Test Alias", LoginState.JOIN);
+        KakaoLoginResponse kakaoLoginResponse = new KakaoLoginResponse("Test Access Token", "Test Refresh Token", "Test Alias", LoginState.JOIN);
 
-        when(authenticationService.login(any())).thenReturn(loginStateResponse);
+        when(authenticationService.login(any())).thenReturn(kakaoLoginResponse);
 
         //when
         ResultActions resultActions = mockMvc.perform(get("/api/member/join?code=testcode")
@@ -65,9 +65,9 @@ class AuthenticationControllerTest {
     @DisplayName("로그인 시 HTTP 상태코드는 200(OK)이며 Alias를 JSON으로 반환한다. Access Token 과 Refresh Token 은 Authorization 헤더에 담아 반환한다.")
     void loginAndState200() throws Exception{
         //given
-        LoginStateResponse loginStateResponse = new LoginStateResponse("Test Access Token", "Test Refresh Token", "Test Alias", LoginState.LOGIN);
+        KakaoLoginResponse kakaoLoginResponse = new KakaoLoginResponse("Test Access Token", "Test Refresh Token", "Test Alias", LoginState.LOGIN);
 
-        when(authenticationService.login(any())).thenReturn(loginStateResponse);
+        when(authenticationService.login(any())).thenReturn(kakaoLoginResponse);
 
         //when
         ResultActions resultActions = mockMvc.perform(get("/api/member/join?code=testcode")

--- a/src/test/java/mokindang/jubging/project_backend/service/authentication/AuthenticationServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/service/authentication/AuthenticationServiceTest.java
@@ -10,7 +10,7 @@ import mokindang.jubging.project_backend.service.member.MemberService;
 import mokindang.jubging.project_backend.service.member.request.RefreshTokenRequest;
 import mokindang.jubging.project_backend.service.member.response.JwtResponse;
 import mokindang.jubging.project_backend.service.member.response.KakaoApiMemberResponse;
-import mokindang.jubging.project_backend.service.member.response.LoginStateResponse;
+import mokindang.jubging.project_backend.service.member.response.KakaoLoginResponse;
 import mokindang.jubging.project_backend.web.jwt.TokenManager;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
@@ -68,14 +68,14 @@ class AuthenticationServiceTest {
         when(tokenManager.createToken(any())).thenReturn("Test Access Token");
 
         //when
-        LoginStateResponse loginStateResponse = authenticationService.login("Test AuthorizedCode");
+        KakaoLoginResponse kakaoLoginResponse = authenticationService.login("Test AuthorizedCode");
 
         //then
-        softly.assertThat(loginStateResponse.getLoginState()).isEqualTo(LoginState.JOIN);
-        softly.assertThat(loginStateResponse.getAccessToken()).isNotEmpty();
-        softly.assertThat(loginStateResponse.getRefreshToken()).isNotEmpty();
-        softly.assertThat(loginStateResponse.getAccessToken()).isNotEqualTo("Kakao Test Access Token");
-        softly.assertThat(loginStateResponse.getRefreshToken()).isNotEqualTo("Kakao Test Refresh Token");
+        softly.assertThat(kakaoLoginResponse.getLoginState()).isEqualTo(LoginState.JOIN);
+        softly.assertThat(kakaoLoginResponse.getAccessToken()).isNotEmpty();
+        softly.assertThat(kakaoLoginResponse.getRefreshToken()).isNotEmpty();
+        softly.assertThat(kakaoLoginResponse.getAccessToken()).isNotEqualTo("Kakao Test Access Token");
+        softly.assertThat(kakaoLoginResponse.getRefreshToken()).isNotEqualTo("Kakao Test Refresh Token");
         softly.assertAll();
         verify(refreshTokenRepository, times(1)).save(any());
     }
@@ -94,12 +94,12 @@ class AuthenticationServiceTest {
         when(refreshTokenRepository.findByMemberId(member.getId())).thenReturn(Optional.of(refreshToken));
 
         //when
-        LoginStateResponse loginStateResponse = authenticationService.login("Test AuthorizedCode");
+        KakaoLoginResponse kakaoLoginResponse = authenticationService.login("Test AuthorizedCode");
 
         //then
-        softly.assertThat(loginStateResponse.getLoginState()).isEqualTo(LoginState.LOGIN);
-        softly.assertThat(loginStateResponse.getAccessToken()).isNotEmpty();
-        softly.assertThat(loginStateResponse.getRefreshToken()).isNotEmpty();
+        softly.assertThat(kakaoLoginResponse.getLoginState()).isEqualTo(LoginState.LOGIN);
+        softly.assertThat(kakaoLoginResponse.getAccessToken()).isNotEmpty();
+        softly.assertThat(kakaoLoginResponse.getRefreshToken()).isNotEmpty();
         softly.assertAll();
         verify(refreshToken, times(1)).switchRefreshToken(any(), any());
 
@@ -118,12 +118,12 @@ class AuthenticationServiceTest {
         when(tokenManager.createToken(any())).thenReturn("Test Access Token");
 
         //when
-        LoginStateResponse loginStateResponse = authenticationService.login("Test AuthorizedCode");
+        KakaoLoginResponse kakaoLoginResponse = authenticationService.login("Test AuthorizedCode");
 
         //then
-        softly.assertThat(loginStateResponse.getLoginState()).isEqualTo(LoginState.LOGIN);
-        softly.assertThat(loginStateResponse.getAccessToken()).isNotEmpty();
-        softly.assertThat(loginStateResponse.getRefreshToken()).isNotEmpty();
+        softly.assertThat(kakaoLoginResponse.getLoginState()).isEqualTo(LoginState.LOGIN);
+        softly.assertThat(kakaoLoginResponse.getAccessToken()).isNotEmpty();
+        softly.assertThat(kakaoLoginResponse.getRefreshToken()).isNotEmpty();
         softly.assertAll();
         verify(refreshTokenRepository, times(1)).save(any());
     }


### PR DESCRIPTION
# dto 수정, 순환 참조 에러 잡기

### 이슈 번호 : #67

## 변경 사항
-    Dto에 사용하지 않는 필드 제거 및 @JsonIgnore 추가
     LoginCheckInterceptor에 sendRedirect 매핑 수정

## 그 외
- Cannot call sendError() after the response has been committed(순환 참조) 내용의 IllegalStateException 에러 해결

## 질문 사항
- 
