### PR TITLE
feature/#124/board 엔티티 region 추가

### DIFF
--- a/src/main/java/mokindang/jubging/project_backend/domain/board/Board.java
+++ b/src/main/java/mokindang/jubging/project_backend/domain/board/Board.java
@@ -7,6 +7,7 @@ import mokindang.jubging.project_backend.domain.board.vo.Content;
 import mokindang.jubging.project_backend.domain.board.vo.StartingDate;
 import mokindang.jubging.project_backend.domain.board.vo.Title;
 import mokindang.jubging.project_backend.domain.member.Member;
+import mokindang.jubging.project_backend.domain.region.vo.Region;
 
 import javax.persistence.*;
 import java.time.LocalDate;
@@ -38,6 +39,9 @@ public class Board {
     @Embedded
     private Content content;
 
+    @Embedded
+    private Region region;
+
     private boolean onRecruitment;
 
     public Board(final Member member, final LocalDate startingDate, final String activityCategory, final String title, final String content, final LocalDate now) {
@@ -46,6 +50,7 @@ public class Board {
         this.activityCategory = ActivityCategory.from(activityCategory);
         this.title = new Title(title);
         this.content = new Content(content);
+        this.region = member.getRegion();
         this.onRecruitment = true;
     }
 

--- a/src/test/java/mokindang/jubging/project_backend/domain/board/BoardTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/domain/board/BoardTest.java
@@ -4,6 +4,7 @@ import mokindang.jubging.project_backend.domain.board.vo.Content;
 import mokindang.jubging.project_backend.domain.board.vo.StartingDate;
 import mokindang.jubging.project_backend.domain.board.vo.Title;
 import mokindang.jubging.project_backend.domain.member.Member;
+import mokindang.jubging.project_backend.domain.region.vo.Region;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,7 +48,7 @@ class BoardTest {
     }
 
     @Test
-    @DisplayName("게시글의 member(작성자), title, content, 활동 종류, 활동 시작일, 모집 여부 를 반환한다.")
+    @DisplayName("게시글의 member(작성자), title, content, 활동 종류, 활동 시작일, 모집 여부, 작성 지역을 반환한다.")
     void getter() {
         //given
         SoftAssertions softly = new SoftAssertions();
@@ -62,6 +63,7 @@ class BoardTest {
         Content content = board.getContent();
         ActivityCategory activityCategory = board.getActivityCategory();
         StartingDate startingDate = board.getStartingDate();
+        Region region = board.getRegion();
         boolean onRecruitment = board.isOnRecruitment();
 
         //then
@@ -71,6 +73,7 @@ class BoardTest {
                 LocalDate.of(2025, 2, 11)));
         softly.assertThat(title).isEqualTo(new Title("게시판 제목"));
         softly.assertThat(content).isEqualTo(new Content("게시판 내용 작성 테스트"));
+        softly.assertThat(region).isEqualTo(member.getRegion());
         softly.assertThat(onRecruitment).isEqualTo(true);
         softly.assertAll();
     }


### PR DESCRIPTION
# board 엔티티 region 추가

### 이슈 번호 : #124

## 변경 사항
-    Board 엔티티에 Region 추가함.

## 그 외
- Board 생성 시, 생성자에서 유저의 Region을 받아 region을 설정하도록 함.

## 질문 사항
- 
