### PR TITLE
Feature/#130/token type bearer 설정하기

### DIFF
--- a/src/main/java/mokindang/jubging/project_backend/web/jwt/TokenManager.java
+++ b/src/main/java/mokindang/jubging/project_backend/web/jwt/TokenManager.java
@@ -13,6 +13,8 @@ import java.util.Date;
 public class TokenManager {
 
     private static final String ISSUER = "mokindang";
+    private static final String MEMBER_ID = "memberId";
+    private static final String TOKEN_TYPE = "Bearer ";
     private final String secretKey;
     private final Long tokenValidateTime;
 
@@ -25,29 +27,31 @@ public class TokenManager {
     public String createToken(Long memberId) {
         Date now = new Date();
         generateKey();
-        return Jwts.builder()
+        String token = Jwts.builder()
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
-                .claim("memberId", memberId)
+                .claim(MEMBER_ID, memberId)
                 .setIssuer(ISSUER)
                 .setIssuedAt(now)
                 .signWith(generateKey(), SignatureAlgorithm.HS256)
                 .setExpiration(new Date(now.getTime() + Duration.ofMinutes(tokenValidateTime).toMillis()))
                 .compact();
+        return TOKEN_TYPE + token;
     }
 
     public Long getMemberId(String token) {
+        String accessToken = parseTokenType(token);
         return Jwts.parserBuilder()
                 .setSigningKey(generateKey())
                 .build()
-                .parseClaimsJws(token)
+                .parseClaimsJws(accessToken)
                 .getBody()
-                .get("memberId",Long.class);
+                .get(MEMBER_ID,Long.class);
     }
-
 
     public boolean validateToken(final String token) {
         try {
-            Jwts.parserBuilder().setSigningKey(generateKey()).build().parseClaimsJws(token);
+            String accessToken = parseTokenType(token);
+            Jwts.parserBuilder().setSigningKey(generateKey()).build().parseClaimsJws(accessToken);
             return true;
         } catch (final io.jsonwebtoken.security.SignatureException | SecurityException | MalformedJwtException exception) {
             throw new JwtException("토큰이 유효하지 않습니다.");
@@ -57,7 +61,13 @@ public class TokenManager {
             throw new JwtException("지원하지 않는 토큰입니다.");
         } catch (final IllegalArgumentException exception) {
             throw new JwtException("JWT 토큰이 잘못되었습니다.");
+        } catch (final ArrayIndexOutOfBoundsException exception) {
+            throw new JwtException("Token 타입이 명시되지 않았습니다.");
         }
+    }
+
+    private String parseTokenType(String token) {
+        return token.split(" ")[1];
     }
 
     private Key generateKey() {

--- a/src/main/java/mokindang/jubging/project_backend/web/jwt/TokenManager.java
+++ b/src/main/java/mokindang/jubging/project_backend/web/jwt/TokenManager.java
@@ -15,6 +15,7 @@ public class TokenManager {
     private static final String ISSUER = "mokindang";
     private static final String MEMBER_ID = "memberId";
     private static final String TOKEN_TYPE = "Bearer ";
+    public static final String DELIMITER = " ";
     private final String secretKey;
     private final Long tokenValidateTime;
 
@@ -67,7 +68,7 @@ public class TokenManager {
     }
 
     private String parseTokenType(String token) {
-        return token.split(" ")[1];
+        return token.split(DELIMITER)[1];
     }
 
     private Key generateKey() {


### PR DESCRIPTION
# token type bearer 설정하기

### 이슈 번호 : #130 

## 변경 사항
-    Access Token 생성 시 Token Type을 Bearer로 명시
     getMemberId() 사용 시 " "  띄어쓰기를 기준으로 split하여 Bearer와 Token 값을 나누어 줌

## 그 외
- 

## 질문 사항
- 
