### PR TITLE
지역 인증 로직 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+        exclude group: 'com.vaadin.external.google'
     }
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation('org.springframework.boot:spring-boot-starter-test') {
+        exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+    }
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'com.mysql:mysql-connector-j'
 }

--- a/src/main/java/mokindang/jubging/project_backend/controller/authentication/AuthenticationController.java
+++ b/src/main/java/mokindang/jubging/project_backend/controller/authentication/AuthenticationController.java
@@ -3,24 +3,17 @@ package mokindang.jubging.project_backend.controller.authentication;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import mokindang.jubging.project_backend.domain.member.LoginState;
-import mokindang.jubging.project_backend.domain.region.vo.Region;
 import mokindang.jubging.project_backend.service.authentication.AuthenticationService;
 import mokindang.jubging.project_backend.service.member.request.AuthorizationCodeRequest;
 import mokindang.jubging.project_backend.service.member.request.RefreshTokenRequest;
-import mokindang.jubging.project_backend.service.member.request.RegionRequest;
 import mokindang.jubging.project_backend.service.member.response.JwtResponse;
 import mokindang.jubging.project_backend.service.member.response.KakaoLoginResponse;
 import mokindang.jubging.project_backend.service.member.response.LoginResponse;
-import mokindang.jubging.project_backend.service.member.response.RegionResponse;
-import mokindang.jubging.project_backend.web.argumentresolver.Login;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.validation.Valid;
 
 @Slf4j
 @RestController
@@ -52,13 +45,5 @@ public class AuthenticationController {
         return ResponseEntity.ok()
                 .header(AUTHORIZATION_HEADER, jwtResponse.getAccessToken(), jwtResponse.getRefreshToken())
                 .build();
-    }
-
-    @PutMapping("/region")
-    public ResponseEntity<RegionResponse> updateRegion(@Valid @RequestBody RegionRequest regionRequest, @Login Long memberId) {
-        Region region = authenticationService.getRegion(regionRequest, memberId);
-        RegionResponse regionResponse = new RegionResponse(region.getValue());
-        return ResponseEntity.ok()
-                .body(regionResponse);
     }
 }

--- a/src/main/java/mokindang/jubging/project_backend/controller/member/MemberController.java
+++ b/src/main/java/mokindang/jubging/project_backend/controller/member/MemberController.java
@@ -1,0 +1,30 @@
+package mokindang.jubging.project_backend.controller.member;
+
+import lombok.RequiredArgsConstructor;
+import mokindang.jubging.project_backend.domain.region.vo.Region;
+import mokindang.jubging.project_backend.service.member.MemberService;
+import mokindang.jubging.project_backend.service.member.request.RegionUpdateRequest;
+import mokindang.jubging.project_backend.service.member.response.RegionUpdateResponse;
+import mokindang.jubging.project_backend.web.argumentresolver.Login;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api/member")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PutMapping("/region")
+    public ResponseEntity<RegionUpdateResponse> updateRegion(@Login Long memberId, @Valid @RequestBody RegionUpdateRequest regionUpdateRequest) {
+        Region updateRegion = memberService.updateRegion(regionUpdateRequest, memberId);
+        return ResponseEntity.ok()
+                .body(new RegionUpdateResponse(updateRegion.getValue()));
+    }
+}

--- a/src/main/java/mokindang/jubging/project_backend/domain/member/Member.java
+++ b/src/main/java/mokindang/jubging/project_backend/domain/member/Member.java
@@ -27,7 +27,11 @@ public class Member {
     public Member(final String email, final String alias) {
         this.email = email;
         this.alias = alias;
-        this.region = new Region("DEFAULT REGION");
+        region = Region.createByDefaultValue();
+    }
+
+    public void updateRegion(final String region) {
+        this.region.updateRegion(region);
     }
 
     @Override

--- a/src/main/java/mokindang/jubging/project_backend/domain/member/Member.java
+++ b/src/main/java/mokindang/jubging/project_backend/domain/member/Member.java
@@ -35,10 +35,6 @@ public class Member {
         this.region.updateRegion(region);
     }
 
-    public void updateRegion(final String region) {
-        this.region = new Region(region);
-    }
-
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;

--- a/src/main/java/mokindang/jubging/project_backend/domain/region/vo/Region.java
+++ b/src/main/java/mokindang/jubging/project_backend/domain/region/vo/Region.java
@@ -13,14 +13,20 @@ import java.util.Objects;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Region {
 
+    private static final String DEFAULT_REGION = "DEFAULT_REGION";
+
     @Column(name = "region")
     private String value;
 
-    public Region(String value) {
+    public static Region createByDefaultValue(){
+        return new Region(DEFAULT_REGION);
+    }
+
+    private Region(String value) {
         this.value = value;
     }
 
-    public void switchRegion(String value) {
+    public void updateRegion(String value) {
         this.value = value;
     }
 

--- a/src/main/java/mokindang/jubging/project_backend/security/kakao/KaKaoLocalApi.java
+++ b/src/main/java/mokindang/jubging/project_backend/security/kakao/KaKaoLocalApi.java
@@ -1,6 +1,6 @@
 package mokindang.jubging.project_backend.security.kakao;
 
-import mokindang.jubging.project_backend.service.member.request.RegionRequest;
+import mokindang.jubging.project_backend.service.member.request.RegionUpdateRequest;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
@@ -14,16 +14,16 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 @Component
-public class KaKaoLocal {
+public class KaKaoLocalApi {
 
     public static final String REGION_2_DEPTH_NAME = "region_2depth_name";
 
-    public String switchCoordinateToRegion(RegionRequest regionRequest){
-        String url = "https://dapi.kakao.com/v2/local/geo/coord2address.json?x="+regionRequest.getLongitude()+"&y="+regionRequest.getLatitude();
+    public String switchCoordinateToRegion(RegionUpdateRequest regionUpdateRequest) {
+        String url = "https://dapi.kakao.com/v2/local/geo/coord2address.json?x=" + regionUpdateRequest.getLongitude() + "&y=" + regionUpdateRequest.getLatitude();
         String addr = "";
-        try{
+        try {
             addr = getRegionAddress(getJSONData(url));
-        }catch(Exception e){
+        } catch (Exception e) {
             e.printStackTrace();
         }
         return addr;
@@ -68,22 +68,22 @@ public class KaKaoLocal {
         JSONObject meta = (JSONObject) jObj.get("meta");
         long size = (long) meta.get("total_count");
 
-        if(size>0){
+        if (size > 0) {
             JSONArray jArray = (JSONArray) jObj.get("documents");
             JSONObject subJobj = (JSONObject) jArray.get(0);
-            JSONObject roadAddress =  (JSONObject) subJobj.get("road_address");
+            JSONObject roadAddress = (JSONObject) subJobj.get("road_address");
 
-            if(roadAddress == null){
+            if (roadAddress == null) {
                 JSONObject subsubJobj = (JSONObject) subJobj.get("address");
                 regionDepth2 = (String) subsubJobj.get(REGION_2_DEPTH_NAME);
-            }else{
+            } else {
                 regionDepth2 = (String) roadAddress.get(REGION_2_DEPTH_NAME);
             }
 
-            if(regionDepth2.equals("") || regionDepth2==null){
+            if (regionDepth2.equals("") || regionDepth2 == null) {
                 subJobj = (JSONObject) jArray.get(1);
                 subJobj = (JSONObject) subJobj.get("address");
-                regionDepth2 =(String) subJobj.get(REGION_2_DEPTH_NAME);
+                regionDepth2 = (String) subJobj.get(REGION_2_DEPTH_NAME);
             }
         }
         return regionDepth2;

--- a/src/main/java/mokindang/jubging/project_backend/service/authentication/AuthenticationService.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/authentication/AuthenticationService.java
@@ -4,15 +4,12 @@ import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import mokindang.jubging.project_backend.domain.member.Member;
-import mokindang.jubging.project_backend.domain.region.vo.Region;
 import mokindang.jubging.project_backend.domain.token.RefreshToken;
 import mokindang.jubging.project_backend.repository.token.RefreshTokenRepository;
-import mokindang.jubging.project_backend.security.kakao.KaKaoLocal;
 import mokindang.jubging.project_backend.security.kakao.KaKaoOAuth2;
 import mokindang.jubging.project_backend.service.member.MemberService;
 import mokindang.jubging.project_backend.service.member.request.AuthorizationCodeRequest;
 import mokindang.jubging.project_backend.service.member.request.RefreshTokenRequest;
-import mokindang.jubging.project_backend.service.member.request.RegionRequest;
 import mokindang.jubging.project_backend.service.member.response.JwtResponse;
 import mokindang.jubging.project_backend.service.member.response.KakaoApiMemberResponse;
 import mokindang.jubging.project_backend.service.member.response.KakaoLoginResponse;
@@ -33,7 +30,6 @@ public class AuthenticationService {
 
     private final MemberService memberService;
     private final KaKaoOAuth2 kakaoOAuth2;
-    private final KaKaoLocal kakaoLocal;
     private final TokenManager tokenManager;
     private final RefreshTokenRepository refreshTokenRepository;
 
@@ -97,15 +93,4 @@ public class AuthenticationService {
         return new JwtResponse(tokenManager.createToken(member.getId()), newRefreshToken);
     }
 
-    public Region getRegion(RegionRequest regionRequest, Long memberId) {
-        Region findRegion = new Region(kakaoLocal.switchCoordinateToRegion(regionRequest));
-        updateRegion(memberId, findRegion);
-        return findRegion;
-    }
-
-    private void updateRegion(Long memberId, Region findRegion) {
-        Member findMember = memberService.findByMemberId(memberId);
-        findMember.getRegion().switchRegion(findRegion.getValue());
-        memberService.saveMember(findMember);
-    }
 }

--- a/src/main/java/mokindang/jubging/project_backend/service/member/MemberService.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/member/MemberService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import mokindang.jubging.project_backend.domain.member.Member;
 import mokindang.jubging.project_backend.domain.region.vo.Region;
 import mokindang.jubging.project_backend.repository.member.MemberRepository;
-import mokindang.jubging.project_backend.security.kakao.KaKaoLocal;
+import mokindang.jubging.project_backend.security.kakao.KaKaoLocalApi;
 import mokindang.jubging.project_backend.service.member.request.RegionUpdateRequest;
 import org.springframework.stereotype.Service;
 
@@ -14,7 +14,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class MemberService {
 
-    private final KaKaoLocal kakaoLocalApi;
+    private final KaKaoLocalApi kakaoLocalApi;
     private final MemberRepository memberRepository;
 
     public Member saveMember(Member member) {

--- a/src/main/java/mokindang/jubging/project_backend/service/member/MemberService.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/member/MemberService.java
@@ -2,7 +2,10 @@ package mokindang.jubging.project_backend.service.member;
 
 import lombok.RequiredArgsConstructor;
 import mokindang.jubging.project_backend.domain.member.Member;
+import mokindang.jubging.project_backend.domain.region.vo.Region;
 import mokindang.jubging.project_backend.repository.member.MemberRepository;
+import mokindang.jubging.project_backend.security.kakao.KaKaoLocal;
+import mokindang.jubging.project_backend.service.member.request.RegionUpdateRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -11,11 +14,13 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class MemberService {
 
+    private final KaKaoLocal kakaoLocalApi;
     private final MemberRepository memberRepository;
 
     public Member saveMember(Member member) {
         return memberRepository.save(member);
     }
+
     public Optional<Member> findByMemberEmail(String memberEmail) {
         return memberRepository.findByEmail(memberEmail);
     }
@@ -23,5 +28,11 @@ public class MemberService {
     public Member findByMemberId(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("해당하는 유저가 존재하지 않습니다."));
+    }
+
+    public Region updateRegion(final RegionUpdateRequest regionUpdateRequest, final Long memberId) {
+        Member member = findByMemberId(memberId);
+        member.updateRegion(kakaoLocalApi.switchCoordinateToRegion(regionUpdateRequest));
+        return member.getRegion();
     }
 }

--- a/src/main/java/mokindang/jubging/project_backend/service/member/request/RegionUpdateRequest.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/member/request/RegionUpdateRequest.java
@@ -8,7 +8,7 @@ import javax.validation.constraints.NotNull;
 
 @Getter
 @RequiredArgsConstructor
-public class RegionRequest {
+public class RegionUpdateRequest {
 
     @NotNull
     @Range(min = 124, max = 132, message = "longitude(경도)는 대한민국 영토 범위 124~132 내의 값이어야 합니다.")

--- a/src/main/java/mokindang/jubging/project_backend/service/member/response/RegionUpdateResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/member/response/RegionUpdateResponse.java
@@ -5,10 +5,10 @@ import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
-public class RegionResponse {
+public class RegionUpdateResponse {
 
     private String region;
 
-    public RegionResponse() {
+    public RegionUpdateResponse() {
     }
 }

--- a/src/test/java/mokindang/jubging/project_backend/controller/authentication/AuthenticationControllerTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/controller/authentication/AuthenticationControllerTest.java
@@ -3,11 +3,9 @@ package mokindang.jubging.project_backend.controller.authentication;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.JwtException;
 import mokindang.jubging.project_backend.domain.member.LoginState;
-import mokindang.jubging.project_backend.domain.region.vo.Region;
 import mokindang.jubging.project_backend.service.authentication.AuthenticationService;
 import mokindang.jubging.project_backend.service.member.request.AuthorizationCodeRequest;
 import mokindang.jubging.project_backend.service.member.request.RefreshTokenRequest;
-import mokindang.jubging.project_backend.service.member.request.RegionRequest;
 import mokindang.jubging.project_backend.service.member.response.JwtResponse;
 import mokindang.jubging.project_backend.service.member.response.KakaoLoginResponse;
 import mokindang.jubging.project_backend.web.jwt.TokenManager;
@@ -23,7 +21,6 @@ import org.springframework.test.web.servlet.ResultActions;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(AuthenticationController.class)
@@ -46,7 +43,7 @@ class AuthenticationControllerTest {
 
     @Test
     @DisplayName("회원가입 시 HTTP 상태코드는 201(CREATED)이며 Alias를 JSON으로 반환한다. Access Token 과 Refresh Token 은 Authorization 헤더에 담아 반환한다.")
-    void joinAndState201() throws Exception{
+    void joinAndState201() throws Exception {
         //given
         KakaoLoginResponse kakaoLoginResponse = new KakaoLoginResponse("Test Access Token", "Test Refresh Token", "Test Alias", LoginState.JOIN);
         AuthorizationCodeRequest authorizationCodeRequest = new AuthorizationCodeRequest("Test Authorization Code");
@@ -66,7 +63,7 @@ class AuthenticationControllerTest {
 
     @Test
     @DisplayName("로그인 시 HTTP 상태코드는 200(OK)이며 Alias를 JSON으로 반환한다. Access Token 과 Refresh Token 은 Authorization 헤더에 담아 반환한다.")
-    void loginAndState200() throws Exception{
+    void loginAndState200() throws Exception {
         //given
         KakaoLoginResponse kakaoLoginResponse = new KakaoLoginResponse("Test Access Token", "Test Refresh Token", "Test Alias", LoginState.LOGIN);
         AuthorizationCodeRequest authorizationCodeRequest = new AuthorizationCodeRequest("Test Authorization Code");
@@ -86,7 +83,7 @@ class AuthenticationControllerTest {
 
     @Test
     @DisplayName("Refresh Token 재발급 요청 시 DB에 해당 Refresh Token 존재하면 새로운 Access Token, Refresh Token 을 재발급 및 상태코드 200(OK)을 반환한다.")
-    void reissue() throws Exception{
+    void reissue() throws Exception {
         //given
         RefreshTokenRequest refreshTokenRequest = new RefreshTokenRequest("Refresh Token");
 
@@ -124,55 +121,5 @@ class AuthenticationControllerTest {
                 .andExpect(jsonPath("$.error").value("Refresh Token 이 존재하지 않습니다."));
     }
 
-    @Test
-    @DisplayName("대한민국 영토 범위 안의 위도와 경도 입력 시 이에 대응하는 지역을 반환한다.")
-    void callRegion() throws Exception {
-        //given
-        RegionRequest regionRequest = new RegionRequest(126.95389562345368, 37.496322794913326);
-
-        when(authenticationService.getRegion(any(), any())).thenReturn(new Region("동작구"));
-
-        //when
-        ResultActions resultActions = mockMvc.perform(put("/region")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(regionRequest)));
-
-        //then
-        resultActions.andExpect(jsonPath("$.region").value("동작구"));
-    }
-
-    @Test
-    @DisplayName("longitude(경도)가 대한민국 영토 범위 124~132에 포함되지 않는 값이 들어온 경우 예외를 반환한다.")
-    void validateLongitude() throws Exception {
-        //given
-        RegionRequest regionRequest = new RegionRequest(115.13181351, 37.496322794913326);
-
-        when(authenticationService.getRegion(any(), any())).thenReturn(new Region("동작구"));
-
-        //when
-        ResultActions resultActions = mockMvc.perform(put("/region")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(regionRequest)));
-
-        //then
-        resultActions.andExpect(jsonPath("$.error").value("longitude(경도)는 대한민국 영토 범위 124~132 내의 값이어야 합니다."));
-    }
-
-    @Test
-    @DisplayName("longitude(경도)가 대한민국 영토 범위 124~132에 포함되지 않는 값이 들어온 경우 예외를 반환한다.")
-    void validateLatitude() throws Exception {
-        //given
-        RegionRequest regionRequest = new RegionRequest(126.95389562345368, 50.335618198);
-
-        when(authenticationService.getRegion(any(), any())).thenReturn(new Region("동작구"));
-
-        //when
-        ResultActions resultActions = mockMvc.perform(put("/region")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(regionRequest)));
-
-        //then
-        resultActions.andExpect(jsonPath("$.error").value("latitude(위도)는 대한민국 영토 범위 33~39 내의 값이어야 합니다."));
-    }
 
 }

--- a/src/test/java/mokindang/jubging/project_backend/controller/member/MemberControllerTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/controller/member/MemberControllerTest.java
@@ -1,0 +1,101 @@
+package mokindang.jubging.project_backend.controller.member;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import mokindang.jubging.project_backend.domain.region.vo.Region;
+import mokindang.jubging.project_backend.repository.member.MemberRepository;
+import mokindang.jubging.project_backend.service.member.MemberService;
+import mokindang.jubging.project_backend.service.member.request.RegionUpdateRequest;
+import mokindang.jubging.project_backend.web.jwt.TokenManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberController.class)
+class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private TokenManager tokenManager;
+
+    @MockBean
+    private MemberService memberService;
+
+    @MockBean
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("대한민국 영토 범위 안의 위도와 경도 입력 시 이에 대응하는 Region을 반환한다.")
+    void callRegion() throws Exception {
+        //given
+        Region region = Region.createByDefaultValue();
+        region.updateRegion("동작구");
+        when(memberService.updateRegion(any(RegionUpdateRequest.class), anyLong())).thenReturn(region);
+
+        RegionUpdateRequest regionUpdateRequest = new RegionUpdateRequest(126.95389562345368, 37.496322794913326);
+
+        //when
+        ResultActions actual = mockMvc.perform(put("/api/member/region")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(regionUpdateRequest)));
+
+        //then
+        actual.andExpect(status().isOk())
+                .andExpect(jsonPath("$.region").value("동작구"));
+    }
+
+    @Test
+    @DisplayName("longitude(경도)가 대한민국 영토 범위 124~132에 포함되지 않는 값이 들어온 경우 예외를 반환한다.")
+    void validateLongitude() throws Exception {
+        //given
+        Region region = Region.createByDefaultValue();
+        region.updateRegion("동작구");
+
+        RegionUpdateRequest regionRequest = new RegionUpdateRequest(115.13181351, 37.496322794913326);
+
+        when(memberService.updateRegion(any(RegionUpdateRequest.class), anyLong())).thenReturn(region);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(put("/api/member/region")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(regionRequest)));
+
+        //then
+        resultActions.andExpect(jsonPath("$.error").value("longitude(경도)는 대한민국 영토 범위 124~132 내의 값이어야 합니다."));
+    }
+
+    @Test
+    @DisplayName("longitude(경도)가 대한민국 영토 범위 124~132에 포함되지 않는 값이 들어온 경우 예외를 반환한다.")
+    void validateLatitude() throws Exception {
+        //given
+        Region region = Region.createByDefaultValue();
+        region.updateRegion("동작구");
+        when(memberService.updateRegion(any(RegionUpdateRequest.class), anyLong())).thenReturn(region);
+
+        RegionUpdateRequest regionRequest = new RegionUpdateRequest(126.95389562345368, 50.335618198);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(put("/api/member/region")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(regionRequest)));
+
+        //then
+        resultActions.andExpect(jsonPath("$.error").value("latitude(위도)는 대한민국 영토 범위 33~39 내의 값이어야 합니다."));
+    }
+}

--- a/src/test/java/mokindang/jubging/project_backend/domain/member/MemberTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/domain/member/MemberTest.java
@@ -4,6 +4,8 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 class MemberTest {
 
     @Test
@@ -21,5 +23,18 @@ class MemberTest {
         softly.assertThat(email).isEqualTo("cjh87467@gmail.com");
         softly.assertThat(alias).isEqualTo("지환");
         softly.assertAll();
+    }
+
+    @Test
+    @DisplayName("사용자의 지역을 변경한다.")
+    void updateRegion() {
+        //given
+        Member member = new Member("test@mail.com", "test");
+
+        //when
+        member.updateRegion("동작구");
+
+        //then
+        assertThat(member.getRegion().getValue()).isEqualTo("동작구");
     }
 }

--- a/src/test/java/mokindang/jubging/project_backend/domain/region/vo/RegionTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/domain/region/vo/RegionTest.java
@@ -1,0 +1,36 @@
+package mokindang.jubging.project_backend.domain.region.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class RegionTest {
+
+    @Test
+    @DisplayName("Region 생성 시, 디폴트 리즌으로 생성을 한다.")
+    void createByDefaultRegion() {
+        //given
+        String expectRegion = "DEFAULT_REGION";
+
+        //when
+        Region region = Region.createByDefaultValue();
+
+        //then
+        assertThat(region.getValue()).isEqualTo(expectRegion);
+    }
+
+    @Test
+    @DisplayName("리즌을 변경한다.")
+    void updateRegion() {
+        //given
+        Region region = Region.createByDefaultValue();
+
+        //when
+        region.updateRegion("동작구");
+
+        //then
+        assertThat(region.getValue()).isEqualTo("동작구");
+    }
+}

--- a/src/test/java/mokindang/jubging/project_backend/domain/region/vo/RegionTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/domain/region/vo/RegionTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 class RegionTest {
 
     @Test

--- a/src/test/java/mokindang/jubging/project_backend/service/member/MemberServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/service/member/MemberServiceTest.java
@@ -1,0 +1,88 @@
+package mokindang.jubging.project_backend.service.member;
+
+import mokindang.jubging.project_backend.domain.member.Member;
+import mokindang.jubging.project_backend.domain.region.vo.Region;
+import mokindang.jubging.project_backend.repository.member.MemberRepository;
+import mokindang.jubging.project_backend.security.kakao.KaKaoLocal;
+import mokindang.jubging.project_backend.service.member.request.RegionUpdateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private KaKaoLocal kaKaoLocalApi;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("Member 를 저장한다.")
+    void saveMember() {
+        //given
+        Member member = new Member("test@emial.com", "test");
+
+        //when
+        memberService.saveMember(member);
+
+        //then
+        verify(memberRepository, times(1)).save(any(Member.class));
+    }
+
+    @Test
+    @DisplayName("memberId로 조회 시 존재하지 않는 member 를 조회하면 예외를 터트린다.")
+    void findByMemberId() {
+        //given
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        //when, then
+        assertThatThrownBy(() -> memberService.findByMemberId(1L)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("해당하는 유저가 존재하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("member email 조회 시  member 를 조회한다.")
+    void findByMemberEmail() {
+        //given
+        Member member = mock(Member.class);
+        when(memberRepository.findByEmail(anyString())).thenReturn(Optional.of(member));
+
+        //when
+        memberService.findByMemberEmail("Test@Email.com");
+
+        //then
+        verify(memberRepository, times(1)).findByEmail(anyString());
+    }
+
+    @Test
+    @DisplayName(" 유저로 부터 입력받은 위치 값을 카카오 api 를 통해 조회해 유저의 지역을 업데이트한다.")
+    void updateRegion() {
+        //given
+        Member member = new Member("test@email.com", "test");
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+        when(kaKaoLocalApi.switchCoordinateToRegion(any(RegionUpdateRequest.class))).thenReturn("동작구");
+
+        RegionUpdateRequest regionUpdateRequest = new RegionUpdateRequest(124.123, 34.512);
+
+        //when
+        Region region = memberService.updateRegion(regionUpdateRequest, 1L);
+
+        //then
+        assertThat(region.getValue()).isEqualTo("동작구");
+    }
+}

--- a/src/test/java/mokindang/jubging/project_backend/service/member/MemberServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/service/member/MemberServiceTest.java
@@ -3,7 +3,7 @@ package mokindang.jubging.project_backend.service.member;
 import mokindang.jubging.project_backend.domain.member.Member;
 import mokindang.jubging.project_backend.domain.region.vo.Region;
 import mokindang.jubging.project_backend.repository.member.MemberRepository;
-import mokindang.jubging.project_backend.security.kakao.KaKaoLocal;
+import mokindang.jubging.project_backend.security.kakao.KaKaoLocalApi;
 import mokindang.jubging.project_backend.service.member.request.RegionUpdateRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,7 +26,7 @@ class MemberServiceTest {
     private MemberRepository memberRepository;
 
     @Mock
-    private KaKaoLocal kaKaoLocalApi;
+    private KaKaoLocalApi kaKaoLocalApi;
 
     @InjectMocks
     private MemberService memberService;


### PR DESCRIPTION
# 지역 인증 로직 리팩토링

### 이슈 번호 : #129 

## 변경 사항
-    사용자 지역인증 로직 MemberController 및 Serivce 로 이전
- 테스트 코드 작성
- 도메인 (Member, Region 코드 변경 및 테스트 코드 작성)

## 그 외
- junit 4 의존성 제거 및 구글 안드로이드 json 의존성 제거

## 질문 사항
- 
