### PR TITLE
Refactor/#168/로그인 api 리팩토링

### DIFF
--- a/src/main/java/mokindang/jubging/project_backend/controller/authentication/AuthenticationController.java
+++ b/src/main/java/mokindang/jubging/project_backend/controller/authentication/AuthenticationController.java
@@ -27,7 +27,7 @@ public class AuthenticationController {
     @PostMapping("/api/member/join")
     public ResponseEntity<LoginResponse> kakaoCallback(@RequestBody AuthorizationCodeRequest authorizationCodeRequest) {
         KakaoLoginResponse kakaoLoginResponse = authenticationService.login(authorizationCodeRequest);
-        LoginResponse loginResponse = new LoginResponse(kakaoLoginResponse.getAlias());
+        LoginResponse loginResponse = new LoginResponse(kakaoLoginResponse.getEmail(), kakaoLoginResponse.getAlias(), kakaoLoginResponse.getRegion());
         ResponseCookie responseCookie = createCookie(kakaoLoginResponse.getRefreshToken());
 
         if (kakaoLoginResponse.getLoginState() == LoginState.JOIN) {

--- a/src/main/java/mokindang/jubging/project_backend/domain/member/Member.java
+++ b/src/main/java/mokindang/jubging/project_backend/domain/member/Member.java
@@ -35,6 +35,10 @@ public class Member {
         this.region.updateRegion(region);
     }
 
+    public String getFourLengthEmail() {
+        return this.email.substring(0, 4);
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;

--- a/src/main/java/mokindang/jubging/project_backend/service/authentication/AuthenticationService.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/authentication/AuthenticationService.java
@@ -48,14 +48,15 @@ public class AuthenticationService {
         log.info("memberId = {}, email = {}, alias = {} 의 로그인", existMember.getId(), kakaoApiMemberResponse.getEmail(), kakaoApiMemberResponse.getAlias());
         JwtResponse jwtResponse = issueJwtToken(existMember);
         return new KakaoLoginResponse(jwtResponse.getAccessToken(),
-                jwtResponse.getRefreshToken(), existMember.getAlias(), LOGIN);
+                jwtResponse.getRefreshToken(), existMember.getFourLengthEmail(), existMember.getAlias(), existMember.getRegion().getValue(), LOGIN);
     }
 
     private KakaoLoginResponse join(final KakaoApiMemberResponse kakaoApiMemberResponse) {
         log.info("email = {}, alias = {} 의 회원 가입", kakaoApiMemberResponse.getEmail(), kakaoApiMemberResponse.getAlias());
         Member newMember = memberService.saveMember(new Member(kakaoApiMemberResponse.getEmail(), kakaoApiMemberResponse.getAlias()));
         JwtResponse jwtResponse = issueJwtToken(newMember);
-        return new KakaoLoginResponse(jwtResponse.getAccessToken(), jwtResponse.getRefreshToken(), newMember.getAlias(), JOIN);
+        return new KakaoLoginResponse(jwtResponse.getAccessToken(),
+                jwtResponse.getRefreshToken(), newMember.getFourLengthEmail(), newMember.getAlias(), newMember.getRegion().getValue(), JOIN);
     }
 
     private JwtResponse issueJwtToken(final Member member) {

--- a/src/main/java/mokindang/jubging/project_backend/service/authentication/KaKaoOAuth2.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/authentication/KaKaoOAuth2.java
@@ -11,19 +11,16 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Component
 public class KaKaoOAuth2 {
 
     public KakaoApiMemberResponse getMemberDto(String authorizationCode) {
-        List<Object> tokens = callKakaoApiToken(authorizationCode);
+        String accessToken = callKakaoApiToken(authorizationCode);
 
-        return getMemberInformation(tokens);
+        return getMemberInformation(accessToken);
     }
 
-    public List<Object> callKakaoApiToken(String authorizationCode) {
+    public String callKakaoApiToken(String authorizationCode) {
         HttpHeaders headers = new HttpHeaders();
         headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
 
@@ -46,23 +43,15 @@ public class KaKaoOAuth2 {
 
         String tokenJson = response.getBody();
         JSONObject rjson = new JSONObject(tokenJson);
-        String accessToken = rjson.getString("access_token");
-        String refreshToken = rjson.getString("refresh_token");
+        String kakaoAccessToken = rjson.getString("access_token");
 
-        List<Object> tokenList = new ArrayList<>();
-        tokenList.add(accessToken);
-        tokenList.add(refreshToken);
-
-        return tokenList;
+        return kakaoAccessToken;
     }
 
-    public KakaoApiMemberResponse getMemberInformation(List<Object> tokenList) {
-
-        String accessToken = (String) tokenList.get(0);
-        String refreshToken = (String) tokenList.get(1);
+    public KakaoApiMemberResponse getMemberInformation(String kakaoAccessToken) {
 
         HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Authorization", "Bearer " + kakaoAccessToken);
         headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
 
         RestTemplate rt = new RestTemplate();
@@ -76,10 +65,10 @@ public class KaKaoOAuth2 {
         );
 
         JSONObject body = new JSONObject(response.getBody());
-        String alias = body.getJSONObject("properties").getString("nickname");
         String email = body.getJSONObject("kakao_account").getString("email");
+        String alias = body.getJSONObject("properties").getString("nickname");
 
-        return new KakaoApiMemberResponse(accessToken, refreshToken, alias, email);
+        return new KakaoApiMemberResponse(email, alias);
     }
 
 }

--- a/src/main/java/mokindang/jubging/project_backend/service/member/response/KakaoApiMemberResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/member/response/KakaoApiMemberResponse.java
@@ -10,14 +10,9 @@ import lombok.RequiredArgsConstructor;
 public class KakaoApiMemberResponse {
 
     @JsonIgnore
-    private final String kakaoAccessToken;
-
-    @JsonIgnore
-    private final String kakaoRefreshToken;
+    private final String email;
 
     @JsonIgnore
     private final String alias;
 
-    @JsonIgnore
-    private final String email;
 }

--- a/src/main/java/mokindang/jubging/project_backend/service/member/response/KakaoLoginResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/member/response/KakaoLoginResponse.java
@@ -15,7 +15,11 @@ public class KakaoLoginResponse {
     @JsonIgnore
     private final String refreshToken;
 
+    private final String email;
+
     private final String alias;
+
+    private final String region;
 
     private final LoginState loginState;
 }

--- a/src/main/java/mokindang/jubging/project_backend/service/member/response/LoginResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/member/response/LoginResponse.java
@@ -1,15 +1,15 @@
 package mokindang.jubging.project_backend.service.member.response;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@RequiredArgsConstructor
 public class LoginResponse {
 
-    private String alias;
+    private final String email;
 
-    public LoginResponse(String alias) {
-        this.alias = alias;
-    }
+    private final String alias;
+
+    private final String region;
 }

--- a/src/main/java/mokindang/jubging/project_backend/web/argumentresolver/LoginMemberArgumentResolver.java
+++ b/src/main/java/mokindang/jubging/project_backend/web/argumentresolver/LoginMemberArgumentResolver.java
@@ -3,6 +3,7 @@ package mokindang.jubging.project_backend.web.argumentresolver;
 import lombok.RequiredArgsConstructor;
 import mokindang.jubging.project_backend.web.jwt.TokenManager;
 import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -24,7 +25,7 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
 
     @Override
     public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer, final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
-        String authorizationHeader = webRequest.getHeader("Authorization");
+        String authorizationHeader = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
         return tokenManager.getMemberId(authorizationHeader);
     }
 }

--- a/src/main/java/mokindang/jubging/project_backend/web/config/OriginConfig.java
+++ b/src/main/java/mokindang/jubging/project_backend/web/config/OriginConfig.java
@@ -1,6 +1,7 @@
 package mokindang.jubging.project_backend.web.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -24,6 +25,6 @@ public class OriginConfig implements WebMvcConfigurer {
                 .allowedMethods(ALLOWED_METHOD_NAMES.split(","))
                 .allowedHeaders("*")
                 .allowCredentials(true)
-                .exposedHeaders("Authorization");
+                .exposedHeaders(HttpHeaders.AUTHORIZATION);
     }
 }

--- a/src/main/java/mokindang/jubging/project_backend/web/interceptor/LoginCheckInterceptor.java
+++ b/src/main/java/mokindang/jubging/project_backend/web/interceptor/LoginCheckInterceptor.java
@@ -2,6 +2,7 @@ package mokindang.jubging.project_backend.web.interceptor;
 
 import lombok.RequiredArgsConstructor;
 import mokindang.jubging.project_backend.web.jwt.TokenManager;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -21,7 +22,7 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
             return true;
         }
         try {
-            String authorizationHeader = request.getHeader("Authorization");
+            String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
             tokenManager.validateToken(authorizationHeader);
         } catch (final RuntimeException e) {
             response.sendRedirect("https://www.dongnejupging.xyz");

--- a/src/test/java/mokindang/jubging/project_backend/controller/authentication/AuthenticationControllerTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/controller/authentication/AuthenticationControllerTest.java
@@ -44,10 +44,10 @@ class AuthenticationControllerTest {
     private TokenManager tokenManager;
 
     @Test
-    @DisplayName("회원가입 시 HTTP 상태코드는 201(CREATED)이며 Alias를 JSON으로 반환한다. Access Token 과 Refresh Token 은 Authorization 헤더에 담아 반환한다.")
+    @DisplayName("회원가입 시 HTTP 상태코드는 201(CREATED)이다. Access Token은 Authorization, Refresh Token은 Set-Cookie 헤더에 담아 응답한다.")
     void joinAndState201() throws Exception {
         //given
-        KakaoLoginResponse kakaoLoginResponse = new KakaoLoginResponse(TEST_ACCESS_TOKEN, TEST_REFRESH_TOKEN, "Test Alias", LoginState.JOIN);
+        KakaoLoginResponse kakaoLoginResponse = new KakaoLoginResponse(TEST_ACCESS_TOKEN, TEST_REFRESH_TOKEN, "dog1", "minho", "동작구", LoginState.JOIN);
         AuthorizationCodeRequest authorizationCodeRequest = new AuthorizationCodeRequest("Test Authorization Code");
 
         when(authenticationService.login(any())).thenReturn(kakaoLoginResponse);
@@ -59,17 +59,18 @@ class AuthenticationControllerTest {
 
         //then
         resultActions.andExpect(status().isCreated())
-                .andExpect(jsonPath("$.alias").value("Test Alias"))
+                .andExpect(jsonPath("$.email").value("dog1"))
+                .andExpect(jsonPath("$.alias").value("minho"))
+                .andExpect(jsonPath("$.region").value("동작구"))
                 .andExpect(header().exists(HttpHeaders.AUTHORIZATION))
-                .andExpect(header().exists(HttpHeaders.SET_COOKIE))
-                .andExpect(header().stringValues("set-cookie","refreshToken=f6341354-be83-11ed-afa1-0242ac120002; Path=/; Secure; HttpOnly"));
+                .andExpect(header().stringValues(HttpHeaders.SET_COOKIE,"refreshToken=f6341354-be83-11ed-afa1-0242ac120002; Path=/; Secure; HttpOnly"));
     }
 
     @Test
-    @DisplayName("로그인 시 HTTP 상태코드는 200(OK)이며 Alias를 JSON으로 반환한다. Access Token 과 Refresh Token 은 Authorization 헤더에 담아 반환한다.")
+    @DisplayName("로그인 시 HTTP 상태코드는 200(OK)이며 Alias를 JSON으로 반환한다. Access Token은 Authorization, Refresh Token은 Set-Cookie 헤더에 담아 응답한다.")
     void loginAndState200() throws Exception {
         //given
-        KakaoLoginResponse kakaoLoginResponse = new KakaoLoginResponse(TEST_ACCESS_TOKEN, TEST_REFRESH_TOKEN, "Test Alias", LoginState.LOGIN);
+        KakaoLoginResponse kakaoLoginResponse = new KakaoLoginResponse(TEST_ACCESS_TOKEN, TEST_REFRESH_TOKEN, "dog1", "minho", "동작구", LoginState.LOGIN);
         AuthorizationCodeRequest authorizationCodeRequest = new AuthorizationCodeRequest("Test Authorization Code");
 
         when(authenticationService.login(any())).thenReturn(kakaoLoginResponse);
@@ -81,10 +82,11 @@ class AuthenticationControllerTest {
 
         //then
         resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.alias").value("Test Alias"))
+                .andExpect(jsonPath("$.email").value("dog1"))
+                .andExpect(jsonPath("$.alias").value("minho"))
+                .andExpect(jsonPath("$.region").value("동작구"))
                 .andExpect(header().exists(HttpHeaders.AUTHORIZATION))
-                .andExpect(header().exists(HttpHeaders.SET_COOKIE))
-                .andExpect(header().stringValues("set-cookie","refreshToken=f6341354-be83-11ed-afa1-0242ac120002; Path=/; Secure; HttpOnly"));
+                .andExpect(header().stringValues(HttpHeaders.SET_COOKIE,"refreshToken=f6341354-be83-11ed-afa1-0242ac120002; Path=/; Secure; HttpOnly"));
     }
 
     @Test
@@ -104,8 +106,7 @@ class AuthenticationControllerTest {
         //then
         resultActions.andExpect(status().isOk())
                 .andExpect(header().exists(HttpHeaders.AUTHORIZATION))
-                .andExpect(header().exists(HttpHeaders.SET_COOKIE))
-                .andExpect(header().stringValues("set-cookie","refreshToken=9ecfd4fe-bee2-11ed-afa1-0242ac120002; Path=/; Secure; HttpOnly"));
+                .andExpect(header().stringValues(HttpHeaders.SET_COOKIE,"refreshToken=9ecfd4fe-bee2-11ed-afa1-0242ac120002; Path=/; Secure; HttpOnly"));
     }
 
     @Test

--- a/src/test/java/mokindang/jubging/project_backend/domain/member/MemberTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/domain/member/MemberTest.java
@@ -37,4 +37,17 @@ class MemberTest {
         //then
         assertThat(member.getRegion().getValue()).isEqualTo("동작구");
     }
+
+    @Test
+    @DisplayName("이메일의 앞자리 4개를 반환한다.")
+    void getFourLengthEmail(){
+        //given
+        Member member = new Member("testfourlength123@mail.com", "test");
+
+        //when
+        String fourLengthEmail = member.getFourLengthEmail();
+
+        //then
+        assertThat(fourLengthEmail).isEqualTo("test");
+    }
 }

--- a/src/test/java/mokindang/jubging/project_backend/service/authentication/AuthenticationServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/service/authentication/AuthenticationServiceTest.java
@@ -54,80 +54,57 @@ class AuthenticationServiceTest {
     private final SoftAssertions softly = new SoftAssertions();
 
     @Test
-    @DisplayName("DB에 email 존재 안할 시 LoginState는 JOIN이다. 회원가입 전 refresh 토큰이 없는 상태로 새로운 access, refresh 토큰을 생성하여 반환한다.")
+    @DisplayName("DB에 email이 없을 시 회원가입 flow를 진행한다. access token, refresh token, email 앞 4자리, alias, region, 로그인 상태 JOIN 을 반환한다.")
     void authenticateJoin() {
         //given
-        Member member = new Member("koho1047@naver.com", "고민호");
-        KakaoApiMemberResponse kakaoApiMemberResponse = new KakaoApiMemberResponse("Kakao Test Access Token",
-                "Kakao Test Refresh Token", "고민호", "koho1047@naver.com");
-        AuthorizationCodeRequest authorizationCodeRequest = new AuthorizationCodeRequest("Test AuthorizedCode");
+        KakaoApiMemberResponse kakaoApiMemberResponse = new KakaoApiMemberResponse("dog123@test.com", "minho");
 
-        when(kakaoOAuth2.getMemberDto(any())).thenReturn(kakaoApiMemberResponse);
+        when(kakaoOAuth2.getMemberDto(anyString())).thenReturn(kakaoApiMemberResponse);
         when(memberService.findByMemberEmail(any())).thenReturn(Optional.empty());
-        when(memberService.saveMember(any())).thenReturn(member);
+        when(memberService.saveMember(any())).thenReturn(new Member("dog123@test.com", "minho"));
         when(tokenManager.createToken(any())).thenReturn("Test Access Token");
 
         //when
-        KakaoLoginResponse kakaoLoginResponse = authenticationService.login(authorizationCodeRequest);
+        KakaoLoginResponse kakaoLoginResponse = authenticationService.login(new AuthorizationCodeRequest("Test Authorization Code"));
 
         //then
+        softly.assertThat(kakaoLoginResponse.getAccessToken()).isEqualTo("Test Access Token");
+        softly.assertThat(kakaoLoginResponse.getRefreshToken()).isNotEmpty();
+        softly.assertThat(kakaoLoginResponse.getEmail()).isEqualTo("dog1");
+        softly.assertThat(kakaoLoginResponse.getAlias()).isEqualTo("minho");
+        softly.assertThat(kakaoLoginResponse.getRegion()).isEqualTo("DEFAULT_REGION");
         softly.assertThat(kakaoLoginResponse.getLoginState()).isEqualTo(LoginState.JOIN);
-        softly.assertThat(kakaoLoginResponse.getAccessToken()).isNotEmpty();
-        softly.assertThat(kakaoLoginResponse.getRefreshToken()).isNotEmpty();
-        softly.assertThat(kakaoLoginResponse.getAccessToken()).isNotEqualTo("Kakao Test Access Token");
-        softly.assertThat(kakaoLoginResponse.getRefreshToken()).isNotEqualTo("Kakao Test Refresh Token");
         softly.assertAll();
         verify(refreshTokenRepository, times(1)).save(any());
-    }
-
-    @Test
-    @DisplayName("DB에 email 존재할 시 LoginState는 LOGIN이다. refresh 토큰이 있으면 토큰을 재발행하여 반환한다.")
-    void authenticateLoginWhenHaveRefreshToken() {
-        //given
-        Member member = new Member("koho1047@naver.com", "고민호");
-        KakaoApiMemberResponse kakaoApiMemberResponse = new KakaoApiMemberResponse("testAccessToken",
-                "testRefreshToken", "고민호", "koho1047@naver.com");
-        AuthorizationCodeRequest authorizationCodeRequest = new AuthorizationCodeRequest("Test AuthorizedCode");
-
-        when(kakaoOAuth2.getMemberDto(any())).thenReturn(kakaoApiMemberResponse);
-        when(memberService.findByMemberEmail(any())).thenReturn(Optional.of(member));
-        when(tokenManager.createToken(member.getId())).thenReturn("Test Access Token");
-        when(refreshTokenRepository.findByMemberId(member.getId())).thenReturn(Optional.of(refreshToken));
-
-        //when
-        KakaoLoginResponse kakaoLoginResponse = authenticationService.login(authorizationCodeRequest);
-
-        //then
-        softly.assertThat(kakaoLoginResponse.getLoginState()).isEqualTo(LoginState.LOGIN);
-        softly.assertThat(kakaoLoginResponse.getAccessToken()).isNotEmpty();
-        softly.assertThat(kakaoLoginResponse.getRefreshToken()).isNotEmpty();
-        softly.assertAll();
-        verify(refreshToken, times(1)).switchRefreshToken(any(), any());
 
     }
 
     @Test
-    @DisplayName("DB에 email 존재할 시 LoginState는 LOGIN이다. DB에 refresh 토큰이 삭제되어 없는경우 토큰을 생성하여 반환한다.")
-    void authenticateLoginWhenHaveNoRefreshToken() {
+    @DisplayName("DB에 email 존재할 시 로그인 flow를 진행한다. access token, refresh token, email 앞 4자리, alias, region, 로그인 상태 LOGIN 을 반환한다.")
+    void authenticateLogin() {
         //given
-        Member member = new Member("koho1047@naver.com", "고민호");
-        KakaoApiMemberResponse kakaoApiMemberResponse = new KakaoApiMemberResponse("testAccessToken",
-                "testRefreshToken", "고민호", "koho1047@naver.com");
-        AuthorizationCodeRequest authorizationCodeRequest = new AuthorizationCodeRequest("Test AuthorizedCode");
+        Member existMember = new Member("dog123@test.com", "minho");
+        existMember.updateRegion("동작구");
+        KakaoApiMemberResponse kakaoApiMemberResponse = new KakaoApiMemberResponse("dog123@test.com", "minho");
 
-        when(kakaoOAuth2.getMemberDto(any())).thenReturn(kakaoApiMemberResponse);
-        when(memberService.findByMemberEmail(any())).thenReturn(Optional.of(member));
+
+        when(kakaoOAuth2.getMemberDto(anyString())).thenReturn(kakaoApiMemberResponse);
+        when(memberService.findByMemberEmail(any())).thenReturn(Optional.of(existMember));
         when(tokenManager.createToken(any())).thenReturn("Test Access Token");
 
         //when
-        KakaoLoginResponse kakaoLoginResponse = authenticationService.login(authorizationCodeRequest);
+        KakaoLoginResponse kakaoLoginResponse = authenticationService.login(new AuthorizationCodeRequest("Test Authorization Code"));
 
         //then
-        softly.assertThat(kakaoLoginResponse.getLoginState()).isEqualTo(LoginState.LOGIN);
-        softly.assertThat(kakaoLoginResponse.getAccessToken()).isNotEmpty();
+        softly.assertThat(kakaoLoginResponse.getAccessToken()).isEqualTo("Test Access Token");
         softly.assertThat(kakaoLoginResponse.getRefreshToken()).isNotEmpty();
+        softly.assertThat(kakaoLoginResponse.getEmail()).isEqualTo("dog1");
+        softly.assertThat(kakaoLoginResponse.getAlias()).isEqualTo("minho");
+        softly.assertThat(kakaoLoginResponse.getRegion()).isEqualTo("동작구");
+        softly.assertThat(kakaoLoginResponse.getLoginState()).isEqualTo(LoginState.LOGIN);
         softly.assertAll();
         verify(refreshTokenRepository, times(1)).save(any());
+
     }
 
     @Test


### PR DESCRIPTION
# Refactor/#168/로그인 api 리팩토링

### 이슈 번호 : #168 

## 변경 사항
- 로그인 API 변경 전 로그인 시 alias 반환 -> 변경 후 email, alias, region 반환
- 이메일 반환 시 앞 4자리만 반환하기 위해 Member에 getFourLengthEmail() 메소드 구현

## 그 외
- 로그인 API 변경에 따른 테스트 코드 수정
- 헤더 "Authorization" -> HttpHeaders.AUTHORIZATINO 수정 

## 질문 사항
- 
