### PR TITLE
Refactor/#179/토큰 재발급 리팩토링

### DIFF
--- a/src/main/java/mokindang/jubging/project_backend/controller/authentication/AuthenticationController.java
+++ b/src/main/java/mokindang/jubging/project_backend/controller/authentication/AuthenticationController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.time.Duration;
 
+import static org.springframework.boot.web.server.Cookie.SameSite.NONE;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.SET_COOKIE;
 
@@ -63,7 +64,7 @@ public class AuthenticationController {
                 .httpOnly(true)
                 .secure(true)
                 .path("/")
-                .sameSite("None")
+                .sameSite(NONE.attributeValue())
                 .maxAge(Duration.ofDays(60))
                 .build();
     }

--- a/src/main/java/mokindang/jubging/project_backend/service/authentication/AuthenticationService.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/authentication/AuthenticationService.java
@@ -76,7 +76,7 @@ public class AuthenticationService {
                         },
                         () -> {
                             LocalDateTime newTokenExpirationTime = LocalDateTime.now()
-                                    .plusMonths(2);
+                                    .plusDays(60);
 
                             RefreshToken refreshToken = new RefreshToken(member.getId(), newRefreshToken, newTokenExpirationTime);
                             refreshTokenRepository.save(refreshToken);

--- a/src/main/java/mokindang/jubging/project_backend/web/config/OriginConfig.java
+++ b/src/main/java/mokindang/jubging/project_backend/web/config/OriginConfig.java
@@ -1,9 +1,10 @@
 package mokindang.jubging.project_backend.web.config;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @Configuration
 public class OriginConfig implements WebMvcConfigurer {
@@ -25,6 +26,6 @@ public class OriginConfig implements WebMvcConfigurer {
                 .allowedMethods(ALLOWED_METHOD_NAMES.split(","))
                 .allowedHeaders("*")
                 .allowCredentials(true)
-                .exposedHeaders(HttpHeaders.AUTHORIZATION);
+                .exposedHeaders(AUTHORIZATION);
     }
 }

--- a/src/main/java/mokindang/jubging/project_backend/web/interceptor/LoginCheckInterceptor.java
+++ b/src/main/java/mokindang/jubging/project_backend/web/interceptor/LoginCheckInterceptor.java
@@ -2,13 +2,14 @@ package mokindang.jubging.project_backend.web.interceptor;
 
 import lombok.RequiredArgsConstructor;
 import mokindang.jubging.project_backend.web.jwt.TokenManager;
-import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @Component
 @RequiredArgsConstructor
@@ -22,7 +23,7 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
             return true;
         }
         try {
-            String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+            String authorizationHeader = request.getHeader(AUTHORIZATION);
             tokenManager.validateToken(authorizationHeader);
         } catch (final RuntimeException e) {
             response.sendRedirect("https://www.dongnejupging.xyz");

--- a/src/test/java/mokindang/jubging/project_backend/controller/authentication/AuthenticationControllerTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/controller/authentication/AuthenticationControllerTest.java
@@ -13,13 +13,16 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import javax.servlet.http.Cookie;
+
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -62,8 +65,8 @@ class AuthenticationControllerTest {
                 .andExpect(jsonPath("$.email").value("dog1"))
                 .andExpect(jsonPath("$.alias").value("minho"))
                 .andExpect(jsonPath("$.region").value("동작구"))
-                .andExpect(header().exists(HttpHeaders.AUTHORIZATION))
-                .andExpect(header().stringValues(HttpHeaders.SET_COOKIE, "refreshToken=f6341354-be83-11ed-afa1-0242ac120002; Path=/; Secure; HttpOnly"));
+                .andExpect(header().exists(AUTHORIZATION))
+                .andExpect(header().exists(SET_COOKIE));
     }
 
     @Test
@@ -85,8 +88,9 @@ class AuthenticationControllerTest {
                 .andExpect(jsonPath("$.email").value("dog1"))
                 .andExpect(jsonPath("$.alias").value("minho"))
                 .andExpect(jsonPath("$.region").value("동작구"))
-                .andExpect(header().exists(HttpHeaders.AUTHORIZATION))
-                .andExpect(header().stringValues(HttpHeaders.SET_COOKIE, "refreshToken=f6341354-be83-11ed-afa1-0242ac120002; Path=/; Secure; HttpOnly"));
+                .andExpect(header().exists(AUTHORIZATION))
+                .andExpect(header().exists(SET_COOKIE));
+
     }
 
     @Test
@@ -99,14 +103,14 @@ class AuthenticationControllerTest {
 
         //when
         ResultActions resultActions = mockMvc.perform(post("/api/member/reissueToken")
-                .header(HttpHeaders.SET_COOKIE, TEST_REFRESH_TOKEN)
+                .cookie(new Cookie("refreshToken", TEST_REFRESH_TOKEN))
                 .contentType(MediaType.APPLICATION_JSON));
 
 
         //then
         resultActions.andExpect(status().isOk())
-                .andExpect(header().exists(HttpHeaders.AUTHORIZATION))
-                .andExpect(header().stringValues(HttpHeaders.SET_COOKIE, "refreshToken=9ecfd4fe-bee2-11ed-afa1-0242ac120002; Path=/; Secure; HttpOnly"));
+                .andExpect(header().exists(AUTHORIZATION))
+                .andExpect(header().exists(SET_COOKIE));
     }
 
     @Test
@@ -117,7 +121,7 @@ class AuthenticationControllerTest {
 
         //when
         ResultActions resultActions = mockMvc.perform(post("/api/member/reissueToken")
-                .header(HttpHeaders.SET_COOKIE, TEST_REFRESH_TOKEN)
+                .cookie(new Cookie("refreshToken", TEST_REFRESH_TOKEN))
                 .contentType(MediaType.APPLICATION_JSON));
 
         //then


### PR DESCRIPTION
# Refactor/#179/토큰 재발급 리팩토링

### 이슈 번호 : #179 

## 변경 사항
-    쿠키 생성 시 옵션 추가
      쿠키 만료 기한 60일 설정, 메인 도메인과 서브 도메인간 쿠키 송수신을 위해 sameSite("None")
-   @CookieValue 어노테이션 사용

## 그 외
- 

## 질문 사항
- 
