### PR TITLE
Refactor/#198/카카오 로그아웃 리팩토링

### DIFF
--- a/src/main/java/mokindang/jubging/project_backend/controller/authentication/AuthenticationController.java
+++ b/src/main/java/mokindang/jubging/project_backend/controller/authentication/AuthenticationController.java
@@ -9,12 +9,10 @@ import mokindang.jubging.project_backend.service.member.response.JwtResponse;
 import mokindang.jubging.project_backend.service.member.response.KakaoLoginResponse;
 import mokindang.jubging.project_backend.service.member.response.LoginResponse;
 import mokindang.jubging.project_backend.web.argumentresolver.Login;
-import org.springframework.http.HttpCookie;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseCookie;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 
+import java.net.URI;
 import java.time.Duration;
 
 import static org.springframework.boot.web.server.Cookie.SameSite.NONE;
@@ -60,9 +58,11 @@ public class AuthenticationController {
 
     @DeleteMapping("/logout")
     public ResponseEntity<Void> logout(@Login Long memberId) {
-        authenticationService.logout(memberId);
-        return ResponseEntity.noContent()
-                .build();
+        String logoutRedirectUrl = authenticationService.logout(memberId);
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setLocation(URI.create(logoutRedirectUrl));
+
+        return new ResponseEntity<>(httpHeaders, HttpStatus.NO_CONTENT);
     }
 
     private ResponseCookie createCookie(String refreshToken) {

--- a/src/main/java/mokindang/jubging/project_backend/service/authentication/AuthenticationService.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/authentication/AuthenticationService.java
@@ -97,9 +97,9 @@ public class AuthenticationService {
     }
 
     @Transactional
-    public void logout(Long memberId) {
+    public String logout(Long memberId) {
         log.info("memberId = {} 의 로그아웃 요청", memberId);
         refreshTokenRepository.deleteAllByMemberId(memberId);
-        kakaoOAuth2.kakaoLogout();
+        return kakaoOAuth2.getKakaoLogoutRedirectUrl();
     }
 }

--- a/src/main/java/mokindang/jubging/project_backend/service/authentication/KaKaoOAuth2.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/authentication/KaKaoOAuth2.java
@@ -74,16 +74,7 @@ public class KaKaoOAuth2 {
         return new KakaoApiMemberResponse(email, alias);
     }
 
-    public void kakaoLogout() {
-        HttpHeaders headers = new HttpHeaders();
-        RestTemplate rt = new RestTemplate();
-        HttpEntity<MultiValueMap<String, String>> kakaoLogoutRequest = new HttpEntity<>(headers);
-
-        rt.exchange(
-                "https://kauth.kakao.com/oauth/logout?client_id="+clientId+"&logout_redirect_uri=https://dongnejupging.xyz",
-                HttpMethod.GET,
-                kakaoLogoutRequest,
-                String.class
-        );
+    public String getKakaoLogoutRedirectUrl() {
+        return "https://kauth.kakao.com/oauth/logout?client_id="+clientId+"&logout_redirect_uri=https://dongnejupging.xyz";
     }
 }

--- a/src/test/java/mokindang/jubging/project_backend/controller/authentication/AuthenticationControllerTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/controller/authentication/AuthenticationControllerTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.SET_COOKIE;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -128,13 +127,5 @@ class AuthenticationControllerTest {
         //then
         resultActions.andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.error").value("Refresh Token 이 존재하지 않습니다."));
-    }
-
-    @Test
-    @DisplayName("로그아웃 시 상태코드 204를 반환하며 요청 유저에 매칭되는 refreshToken을 DB에서 삭제 및 카카오 세션 만료 요청을 수행한다.")
-    void logout() throws Exception{
-        //when,then
-        mockMvc.perform(delete("/api/auth/logout"))
-                .andExpect(status().isNoContent());
     }
 }

--- a/src/test/java/mokindang/jubging/project_backend/service/authentication/AuthenticationServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/service/authentication/AuthenticationServiceTest.java
@@ -149,6 +149,6 @@ class AuthenticationServiceTest {
 
         //then
         verify(refreshTokenRepository, times(1)).deleteAllByMemberId(member.getId());
-        verify(kakaoOAuth2, times(1)).kakaoLogout();
+        verify(kakaoOAuth2, times(1)).getKakaoLogoutRedirectUrl();
     }
 }


### PR DESCRIPTION
# Refactor/#198/카카오 로그아웃 리팩토링

### 이슈 번호 : #198 

## 변경 사항
-    로그아웃 요청 시 redirect url을 헤더에 setLocation에 담아 반환

## 그 외
- 

## 질문 사항
- 
