### PR TITLE
Refactor/#170/게시글 조회 시 반환값 추가

### DIFF
--- a/src/main/java/mokindang/jubging/project_backend/controller/board/BoardController.java
+++ b/src/main/java/mokindang/jubging/project_backend/controller/board/BoardController.java
@@ -63,7 +63,7 @@ public class BoardController {
                     "존재하지 않는 게시글 조회", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
     @GetMapping("/{boardId}")
-    public ResponseEntity<BoardSelectResponse> selectBoard(@Parameter(hidden = true) @Login Long memberId, @PathVariable final Long boardId) {
+    public ResponseEntity<BoardSelectResponse> selectBoard(@Parameter(hidden = true) @Login final Long memberId, @PathVariable final Long boardId) {
         log.info("memberId = [} 의 게시글 조회, 게시글 번호 : {}", memberId, boardId);
         BoardSelectResponse boardSelectResponse = boardService.select(memberId, boardId);
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/mokindang/jubging/project_backend/domain/board/Board.java
+++ b/src/main/java/mokindang/jubging/project_backend/domain/board/Board.java
@@ -72,6 +72,10 @@ public class Board {
         }
     }
 
+    public boolean isWriter(final Member member) {
+        return this.writer.equals(member);
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;

--- a/src/main/java/mokindang/jubging/project_backend/service/board/BoardService.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/board/BoardService.java
@@ -32,6 +32,6 @@ public class BoardService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시물입니다."));
         board.checkRegion(logindMember.getRegion());
         return new BoardSelectResponse(board.getId(), board.getTitle().getValue(), board.getContent().getValue(), board.getWriter().getAlias(),
-                board.getStartingDate().getValue(), board.getWritingRegion().getValue(), board.getActivityCategory().getValue(), board.isOnRecruitment(), board.getWriter().getFourLengthEmail());
-    }
-}
+                board.getStartingDate().getValue(), board.getWritingRegion().getValue(), board.getActivityCategory().getValue(),
+                board.isOnRecruitment(), board.getWriter().getFourLengthEmail(), board.isWriter(logindMember));
+    }}

--- a/src/main/java/mokindang/jubging/project_backend/service/board/BoardService.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/board/BoardService.java
@@ -32,6 +32,6 @@ public class BoardService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시물입니다."));
         board.checkRegion(logindMember.getRegion());
         return new BoardSelectResponse(board.getId(), board.getTitle().getValue(), board.getContent().getValue(), board.getWriter().getAlias(),
-                board.getStartingDate().getValue(), board.getWritingRegion().getValue(), board.getActivityCategory().getValue(), board.isOnRecruitment());
+                board.getStartingDate().getValue(), board.getWritingRegion().getValue(), board.getActivityCategory().getValue(), board.isOnRecruitment(), board.getWriter().getFourLengthEmail());
     }
 }

--- a/src/main/java/mokindang/jubging/project_backend/service/board/response/BoardSelectResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/board/response/BoardSelectResponse.java
@@ -36,5 +36,5 @@ public class BoardSelectResponse {
     private String firstFourLettersOfEmail;
 
     @Schema(description = "게시글 조회 회원이, 작성자인지에 대한 정보", allowableValues = {"true", "false"})
-    private boolean isWriter;
+    private boolean mine;
 }

--- a/src/main/java/mokindang/jubging/project_backend/service/board/response/BoardSelectResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/board/response/BoardSelectResponse.java
@@ -31,4 +31,7 @@ public class BoardSelectResponse {
 
     @Schema(description = "모집 여부")
     private boolean onRecruitment;
+
+    @Schema(description = "게시글 작성자의 이메일 앞 4글자")
+    private String firstFourLettersOfEmail;
 }

--- a/src/main/java/mokindang/jubging/project_backend/service/board/response/BoardSelectResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/board/response/BoardSelectResponse.java
@@ -34,4 +34,7 @@ public class BoardSelectResponse {
 
     @Schema(description = "게시글 작성자의 이메일 앞 4글자")
     private String firstFourLettersOfEmail;
+
+    @Schema(description = "게시글 조회 회원이, 작성자인지에 대한 정보", allowableValues = {"true", "false"})
+    private boolean isWriter;
 }

--- a/src/test/java/mokindang/jubging/project_backend/controller/board/BoardControllerTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/controller/board/BoardControllerTest.java
@@ -161,7 +161,7 @@ class BoardControllerTest {
                 .andExpect(jsonPath("$.activityCategory").value("달리기"))
                 .andExpect(jsonPath("$.onRecruitment").value(true))
                 .andExpect(jsonPath("$.firstFourLettersOfEmail").value("test"))
-                .andExpect(jsonPath("$.isWriter").value(true));
+                .andExpect(jsonPath("$.mine").value(true));
     }
 
     @Test

--- a/src/test/java/mokindang/jubging/project_backend/controller/board/BoardControllerTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/controller/board/BoardControllerTest.java
@@ -143,7 +143,7 @@ class BoardControllerTest {
         //given
         LocalDate now = LocalDate.of(2023, 3, 9);
         BoardSelectResponse boardSelectResponse = new BoardSelectResponse(1L, "제목", "본문", "작성자",
-                "2023-03-10", "동작구", "달리기", true);
+                "2023-03-10", "동작구", "달리기", true, "test");
         when(boardService.select(anyLong(), anyLong())).thenReturn(boardSelectResponse);
 
         //when
@@ -159,7 +159,8 @@ class BoardControllerTest {
                 .andExpect(jsonPath("$.startingDate").value("2023-03-10"))
                 .andExpect(jsonPath("$.region").value("동작구"))
                 .andExpect(jsonPath("$.activityCategory").value("달리기"))
-                .andExpect(jsonPath("onRecruitment").value("true"));
+                .andExpect(jsonPath("$.onRecruitment").value("true"))
+                .andExpect(jsonPath("$.firstFourLettersOfEmail").value("test"));
     }
 
     @Test

--- a/src/test/java/mokindang/jubging/project_backend/controller/board/BoardControllerTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/controller/board/BoardControllerTest.java
@@ -143,7 +143,7 @@ class BoardControllerTest {
         //given
         LocalDate now = LocalDate.of(2023, 3, 9);
         BoardSelectResponse boardSelectResponse = new BoardSelectResponse(1L, "제목", "본문", "작성자",
-                "2023-03-10", "동작구", "달리기", true, "test");
+                "2023-03-10", "동작구", "달리기", true, "test", true);
         when(boardService.select(anyLong(), anyLong())).thenReturn(boardSelectResponse);
 
         //when
@@ -159,8 +159,9 @@ class BoardControllerTest {
                 .andExpect(jsonPath("$.startingDate").value("2023-03-10"))
                 .andExpect(jsonPath("$.region").value("동작구"))
                 .andExpect(jsonPath("$.activityCategory").value("달리기"))
-                .andExpect(jsonPath("$.onRecruitment").value("true"))
-                .andExpect(jsonPath("$.firstFourLettersOfEmail").value("test"));
+                .andExpect(jsonPath("$.onRecruitment").value(true))
+                .andExpect(jsonPath("$.firstFourLettersOfEmail").value("test"))
+                .andExpect(jsonPath("$.isWriter").value(true));
     }
 
     @Test

--- a/src/test/java/mokindang/jubging/project_backend/domain/board/BoardTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/domain/board/BoardTest.java
@@ -8,13 +8,24 @@ import mokindang.jubging.project_backend.domain.region.vo.Region;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.annotation.Rollback;
 
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import java.time.LocalDate;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Rollback
+@DataJpaTest
 class BoardTest {
+
+    @PersistenceContext
+    private EntityManager em;
 
     @Test
     @DisplayName("게시글 생성 시, 모집 여부는 상태는 항상 true 이다.")
@@ -127,5 +138,52 @@ class BoardTest {
 
         //then
         assertThat(actual).isEqualTo("민호");
+    }
+
+    @Test
+    @DisplayName("게시글 작성자인지 확인한다. 작성자인경우 true 를 반환한다.")
+    void isWriter() {
+        //given
+        LocalDate now = LocalDate.of(2023, 11, 12);
+        Member writer = new Member("test1@email.com", "test");
+        writer.updateRegion("동작구");
+        Board board = new Board(writer, LocalDate.of(2025, 2, 11), "달리기",
+                "제목", "본문내용", now);
+
+        em.persist(writer);
+        em.persist(board);
+        em.flush();
+        em.clear();
+
+        //when
+        boolean actual = board.isWriter(writer);
+
+        //then
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    @DisplayName("게시글 작성자인지 확인한다. 작성자가 아닌경우 false 를 반환한다.")
+    void isWriterWhenNoneWriter() {
+        //given
+        LocalDate now = LocalDate.of(2023, 11, 12);
+        Member writer = new Member("test1@email.com", "test");
+        writer.updateRegion("동작구");
+        Board board = new Board(writer, LocalDate.of(2025, 2, 11), "달리기",
+                "제목", "본문내용", now);
+
+        Member noneWriter = new Member("noneWriter@test.com", "noneWriter");
+
+        em.persist(writer);
+        em.persist(board);
+        em.persist(noneWriter);
+        em.flush();
+        em.clear();
+
+        //when
+        boolean actual = board.isWriter(noneWriter);
+
+        //then
+        assertThat(actual).isFalse();
     }
 }

--- a/src/test/java/mokindang/jubging/project_backend/service/board/BoardServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/service/board/BoardServiceTest.java
@@ -92,6 +92,7 @@ class BoardServiceTest {
         LocalDate now = LocalDate.of(2023, 3, 10);
         when(board.getStartingDate()).thenReturn(new StartingDate(now, LocalDate.of(2023, 3, 11)));
         when(board.getWriter().getFourLengthEmail()).thenReturn("test");
+        when(board.isWriter(member)).thenReturn(true);
         when(boardRepository.findById(1L)).thenReturn(Optional.of(board));
 
         //when
@@ -106,6 +107,7 @@ class BoardServiceTest {
         softly.assertThat(actual.getActivityCategory()).isEqualTo("달리기");
         softly.assertThat(actual.isOnRecruitment()).isEqualTo(true);
         softly.assertThat(actual.getFirstFourLettersOfEmail()).isEqualTo("test");
+        softly.assertThat(actual.isWriter()).isEqualTo(true);
         softly.assertAll();
     }
 }

--- a/src/test/java/mokindang/jubging/project_backend/service/board/BoardServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/service/board/BoardServiceTest.java
@@ -107,7 +107,7 @@ class BoardServiceTest {
         softly.assertThat(actual.getActivityCategory()).isEqualTo("달리기");
         softly.assertThat(actual.isOnRecruitment()).isEqualTo(true);
         softly.assertThat(actual.getFirstFourLettersOfEmail()).isEqualTo("test");
-        softly.assertThat(actual.isWriter()).isEqualTo(true);
+        softly.assertThat(actual.isMine()).isEqualTo(true);
         softly.assertAll();
     }
 }

--- a/src/test/java/mokindang/jubging/project_backend/service/board/BoardServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/service/board/BoardServiceTest.java
@@ -88,17 +88,24 @@ class BoardServiceTest {
         when(board.getWriter().getAlias()).thenReturn("글작성자");
         when(board.getWritingRegion()).thenReturn(Region.from("동작구"));
         when(board.getActivityCategory()).thenReturn(ActivityCategory.RUNNING);
+        when(board.isOnRecruitment()).thenReturn(true);
         LocalDate now = LocalDate.of(2023, 3, 10);
         when(board.getStartingDate()).thenReturn(new StartingDate(now, LocalDate.of(2023, 3, 11)));
+        when(board.getWriter().getFourLengthEmail()).thenReturn("test");
         when(boardRepository.findById(1L)).thenReturn(Optional.of(board));
-        when(member.getRegion()).thenReturn(Region.from("동작구"));
 
         //when
         BoardSelectResponse actual = boardService.select(1L, 1L);
 
         //then
         softly.assertThat(actual.getBoardId()).isEqualTo(1L);
-        softly.assertThat(actual.getTitle()).isEqualTo("제목");
-        softly.assertThat(actual.getWriterAlias()).isEqualTo("test");
+        softly.assertThat(actual.getTitle()).isEqualTo("제목입니다.");
+        softly.assertThat(actual.getContent()).isEqualTo("본문내용입니다.");
+        softly.assertThat(actual.getWriterAlias()).isEqualTo("글작성자");
+        softly.assertThat(actual.getStartingDate()).isEqualTo("2023-03-11");
+        softly.assertThat(actual.getActivityCategory()).isEqualTo("달리기");
+        softly.assertThat(actual.isOnRecruitment()).isEqualTo(true);
+        softly.assertThat(actual.getFirstFourLettersOfEmail()).isEqualTo("test");
+        softly.assertAll();
     }
 }


### PR DESCRIPTION
# Refactor/#170/게시글 조회 시 반환값 추가

### 이슈 번호 : #170

## 변경 사항
-    게시글 조회 시 반환 값추가에 따른 `BoardSelectResponse` 변경
    - 게시글 조회한 회원이 작성자인지에 대한 값인 `boolean` 타입 `isWriter` 추가 
    - 게시글 작성자의 이메일 앞 4자리  `firstFourLettersOfEmail` 추가

## 그 외
- 

## 질문 사항
- 
