### PR TITLE
Refactor/#271/전체 게시글 조회 리팩토링

### DIFF
--- a/src/main/java/mokindang/jubging/project_backend/domain/board/Board.java
+++ b/src/main/java/mokindang/jubging/project_backend/domain/board/Board.java
@@ -92,6 +92,11 @@ public class Board {
         return this.writer.equals(member);
     }
 
+    public String getWriterProfileImageUrl() {
+        return writer.getProfileImage()
+                .getProfileImageUrl();
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;

--- a/src/main/java/mokindang/jubging/project_backend/service/board/BoardService.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/board/BoardService.java
@@ -55,7 +55,7 @@ public class BoardService {
         return new BoardSelectionResponse(board.getId(), board.getTitle().getValue(), board.getContent().getValue(),
                 board.getCreatingDateTime(), board.getWriter().getAlias(), board.getStartingDate().getValue(),
                 board.getWritingRegion().getValue(), board.getActivityCategory().getValue(), board.isOnRecruitment(),
-                board.getWriter().getFourLengthEmail(), board.isWriter(logindMember));
+                board.getWriter().getFourLengthEmail(), logindMember.getProfileImage().getProfileImageUrl(), board.isWriter(logindMember));
     }
 
     public MultiBoardSelectResponse selectAllBoards(final Pageable pageable) {

--- a/src/main/java/mokindang/jubging/project_backend/service/board/BoardService.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/board/BoardService.java
@@ -68,8 +68,9 @@ public class BoardService {
 
     private SummaryBoardResponse convertToSummaryBoard(final Board board) {
         return new SummaryBoardResponse(board.getId(), board.getTitle().getValue(), board.getContent().getValue(),
-                board.getWriter().getAlias(), board.getStartingDate().getValue(), board.getWritingRegion().getValue(),
-                board.getActivityCategory().getValue(), board.isOnRecruitment(), board.getWriter().getFourLengthEmail());
+                board.getWriter().getAlias(), board.getWriterProfileImageUrl(), board.getStartingDate().getValue(),
+                board.getWritingRegion().getValue(), board.getActivityCategory().getValue(),
+                board.isOnRecruitment(), board.getWriter().getFourLengthEmail());
     }
 
     @Transactional

--- a/src/main/java/mokindang/jubging/project_backend/service/board/BoardService.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/board/BoardService.java
@@ -55,7 +55,7 @@ public class BoardService {
         return new BoardSelectionResponse(board.getId(), board.getTitle().getValue(), board.getContent().getValue(),
                 board.getCreatingDateTime(), board.getWriter().getAlias(), board.getStartingDate().getValue(),
                 board.getWritingRegion().getValue(), board.getActivityCategory().getValue(), board.isOnRecruitment(),
-                board.getWriter().getFourLengthEmail(), logindMember.getProfileImage().getProfileImageUrl(), board.isWriter(logindMember));
+                board.getWriter().getFourLengthEmail(), board.getWriterProfileImageUrl(), board.isWriter(logindMember));
     }
 
     public MultiBoardSelectResponse selectAllBoards(final Pageable pageable) {

--- a/src/main/java/mokindang/jubging/project_backend/service/board/response/BoardSelectionResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/board/response/BoardSelectionResponse.java
@@ -40,6 +40,9 @@ public class BoardSelectionResponse {
     @Schema(description = "게시글 작성자의 이메일 앞 4글자")
     private String firstFourLettersOfEmail;
 
+    @Schema(description = "게시글 작성자의 프로필 경로")
+    private String writerProfileImage;
+
     @Schema(description = "게시글 조회 회원이, 작성자인지에 대한 정보", allowableValues = {"true", "false"})
     private boolean mine;
 }

--- a/src/main/java/mokindang/jubging/project_backend/service/board/response/SummaryBoardResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/board/response/SummaryBoardResponse.java
@@ -20,6 +20,9 @@ public class SummaryBoardResponse {
     @Schema(description = "작성자", example = "작성자닉네임")
     private String writerAlias;
 
+    @Schema(description = "작성자 프로필 url")
+    private String writerProfileUrl;
+
     @Schema(description = "활동 예정일", example = "2023-12-11")
     private String startingDate;
 

--- a/src/test/java/mokindang/jubging/project_backend/controller/board/BoardControllerTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/controller/board/BoardControllerTest.java
@@ -150,7 +150,7 @@ class BoardControllerTest {
         //given
         LocalDateTime now = LocalDateTime.of(2023, 3, 30, 11, 11);
         BoardSelectionResponse boardSelectionResponse = new BoardSelectionResponse(1L, "제목", "본문", now, "작성자",
-                "2023-03-10", "동작구", "달리기", true, "test", true);
+                "2023-03-10", "동작구", "달리기", true, "test", "test_profile_url",true);
         when(boardService.select(anyLong(), anyLong())).thenReturn(boardSelectionResponse);
 
         //when
@@ -167,6 +167,7 @@ class BoardControllerTest {
                 .andExpect(jsonPath("$.region").value("동작구"))
                 .andExpect(jsonPath("$.activityCategory").value("달리기"))
                 .andExpect(jsonPath("$.onRecruitment").value(true))
+                .andExpect(jsonPath("$.writerProfileImage").value("test_profile_url"))
                 .andExpect(jsonPath("$.firstFourLettersOfEmail").value("test"))
                 .andExpect(jsonPath("$.mine").value(true))
                 .andExpect(jsonPath("$.creatingDatetime").value("2023-03-30T11:11:00"));

--- a/src/test/java/mokindang/jubging/project_backend/domain/board/BoardTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/domain/board/BoardTest.java
@@ -209,4 +209,24 @@ class BoardTest {
         softly.assertThat(board.getContent().getValue()).isEqualTo(newContentValue);
         softly.assertAll();
     }
+
+    @Test
+    @DisplayName("게시글 작성자의 프로필 이미지 url 을 불러온다.")
+    void getWriterProfileImageUrl() {
+        //given
+        String testUrl = "test_url";
+
+        LocalDateTime now = LocalDateTime.of(2023, 11, 12, 0, 0, 0);
+        Member writer = new Member("test1@email.com", "test");
+        writer.updateRegion("동작구");
+        writer.updateProfileImage(testUrl, "test_Image");
+        Board board = new Board(now, writer, LocalDate.of(2025, 2, 11), "달리기",
+                "제목", "본문내용");
+
+        //when
+        String writerProfileImageUrl = board.getWriterProfileImageUrl();
+
+        //then
+        assertThat(writerProfileImageUrl).isEqualTo(testUrl);
+    }
 }

--- a/src/test/java/mokindang/jubging/project_backend/service/board/BoardServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/service/board/BoardServiceTest.java
@@ -6,7 +6,6 @@ import mokindang.jubging.project_backend.domain.board.vo.Content;
 import mokindang.jubging.project_backend.domain.board.vo.StartingDate;
 import mokindang.jubging.project_backend.domain.board.vo.Title;
 import mokindang.jubging.project_backend.domain.member.Member;
-import mokindang.jubging.project_backend.domain.member.vo.ProfileImage;
 import mokindang.jubging.project_backend.domain.member.vo.Region;
 import mokindang.jubging.project_backend.exception.custom.ForbiddenException;
 import mokindang.jubging.project_backend.repository.board.BoardRepository;

--- a/src/test/java/mokindang/jubging/project_backend/service/board/BoardServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/service/board/BoardServiceTest.java
@@ -89,7 +89,6 @@ class BoardServiceTest {
         //given
         SoftAssertions softly = new SoftAssertions();
         Member member = mock(Member.class);
-        when(member.getProfileImage()).thenReturn(new ProfileImage("test_url", "test_name"));
         when(memberService.findByMemberId(anyLong())).thenReturn(member);
 
         Board board = mock(Board.class);
@@ -104,6 +103,7 @@ class BoardServiceTest {
         LocalDate now = LocalDate.of(2023, 3, 10);
         when(board.getStartingDate()).thenReturn(new StartingDate(now, LocalDate.of(2023, 3, 11)));
         when(board.getWriter().getFourLengthEmail()).thenReturn("test");
+        when(board.getWriterProfileImageUrl()).thenReturn("test_url");
         when(board.isWriter(member)).thenReturn(true);
         when(boardRepository.findById(1L)).thenReturn(Optional.of(board));
 

--- a/src/test/java/mokindang/jubging/project_backend/service/board/BoardServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/service/board/BoardServiceTest.java
@@ -6,6 +6,7 @@ import mokindang.jubging.project_backend.domain.board.vo.Content;
 import mokindang.jubging.project_backend.domain.board.vo.StartingDate;
 import mokindang.jubging.project_backend.domain.board.vo.Title;
 import mokindang.jubging.project_backend.domain.member.Member;
+import mokindang.jubging.project_backend.domain.member.vo.ProfileImage;
 import mokindang.jubging.project_backend.domain.member.vo.Region;
 import mokindang.jubging.project_backend.exception.custom.ForbiddenException;
 import mokindang.jubging.project_backend.repository.board.BoardRepository;
@@ -88,6 +89,7 @@ class BoardServiceTest {
         //given
         SoftAssertions softly = new SoftAssertions();
         Member member = mock(Member.class);
+        when(member.getProfileImage()).thenReturn(new ProfileImage("test_url", "test_name"));
         when(memberService.findByMemberId(anyLong())).thenReturn(member);
 
         Board board = mock(Board.class);
@@ -116,6 +118,7 @@ class BoardServiceTest {
         softly.assertThat(actual.getStartingDate()).isEqualTo("2023-03-11");
         softly.assertThat(actual.getActivityCategory()).isEqualTo("달리기");
         softly.assertThat(actual.isOnRecruitment()).isEqualTo(true);
+        softly.assertThat(actual.getWriterProfileImage()).isEqualTo("test_url");
         softly.assertThat(actual.getFirstFourLettersOfEmail()).isEqualTo("test");
         softly.assertThat(actual.isMine()).isEqualTo(true);
         softly.assertAll();


### PR DESCRIPTION
# Refactor/#271/전체 게시글 조회 리팩토링

### 이슈 번호 : #271 

## 변경 사항
-    전체 게시글 조회 시, 각 게시글 작성자의 프로필 이미지 url 를 포함 하도록 변경

## 그 외
- #269 의 작업 내용이 필요하여 merge 후 작업 함.

## 질문 사항
- 
