### PR TITLE
Feature/#284/인증게시글 조회 구현

### DIFF
--- a/src/main/java/mokindang/jubging/project_backend/controller/board/certificationboard/CertificationBoardController.java
+++ b/src/main/java/mokindang/jubging/project_backend/controller/board/certificationboard/CertificationBoardController.java
@@ -5,14 +5,14 @@ import lombok.extern.slf4j.Slf4j;
 import mokindang.jubging.project_backend.service.board.certificationboard.CertificationBoardService;
 import mokindang.jubging.project_backend.service.board.certificationboard.request.CertificationBoardCreationRequest;
 import mokindang.jubging.project_backend.service.board.certificationboard.response.CertificationBoardIdResponse;
+import mokindang.jubging.project_backend.service.board.certificationboard.response.CertificationBoardSelectionResponse;
+import mokindang.jubging.project_backend.service.board.certificationboard.response.MultiCertificationBoardSelectResponse;
 import mokindang.jubging.project_backend.web.argumentresolver.Login;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -30,5 +30,20 @@ public class CertificationBoardController implements CertificationBoardControlle
         CertificationBoardIdResponse certificationBoardIdResponse = certificationBoardService.write(memberId, certificationBoardCreationRequest);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(certificationBoardIdResponse);
+    }
+
+    @GetMapping("/{boardId}")
+    public ResponseEntity<CertificationBoardSelectionResponse> selectBoard(@Login final Long memberId, @PathVariable final Long boardId) {
+        log.info("memberId = {} 의 게시글 조회 요청, 게시글 번호 : {}", memberId, boardId);
+        CertificationBoardSelectionResponse certificationBoardSelectionResponse = certificationBoardService.select(memberId, boardId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(certificationBoardSelectionResponse);
+    }
+
+    @GetMapping
+    public ResponseEntity<MultiCertificationBoardSelectResponse> selectBoards(final Pageable pageable) {
+        MultiCertificationBoardSelectResponse multiCertificationBoardSelectResponse = certificationBoardService.selectAllBoards(pageable);
+        return ResponseEntity.ok()
+                .body(multiCertificationBoardSelectResponse);
     }
 }

--- a/src/main/java/mokindang/jubging/project_backend/controller/board/certificationboard/CertificationBoardController.java
+++ b/src/main/java/mokindang/jubging/project_backend/controller/board/certificationboard/CertificationBoardController.java
@@ -34,7 +34,7 @@ public class CertificationBoardController implements CertificationBoardControlle
 
     @GetMapping("/{boardId}")
     public ResponseEntity<CertificationBoardSelectionResponse> selectBoard(@Login final Long memberId, @PathVariable final Long boardId) {
-        log.info("memberId = {} 의 게시글 조회 요청, 게시글 번호 : {}", memberId, boardId);
+        log.info("memberId = {} 의 인증 게시글 조회 요청, 인증 게시글 번호 : {}", memberId, boardId);
         CertificationBoardSelectionResponse certificationBoardSelectionResponse = certificationBoardService.select(memberId, boardId);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(certificationBoardSelectionResponse);

--- a/src/main/java/mokindang/jubging/project_backend/controller/board/certificationboard/CertificationBoardControllerSwagger.java
+++ b/src/main/java/mokindang/jubging/project_backend/controller/board/certificationboard/CertificationBoardControllerSwagger.java
@@ -11,9 +11,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import mokindang.jubging.project_backend.exception.ErrorResponse;
 import mokindang.jubging.project_backend.service.board.certificationboard.request.CertificationBoardCreationRequest;
 import mokindang.jubging.project_backend.service.board.certificationboard.response.CertificationBoardIdResponse;
+import mokindang.jubging.project_backend.service.board.certificationboard.response.CertificationBoardSelectionResponse;
+import mokindang.jubging.project_backend.service.board.certificationboard.response.MultiCertificationBoardSelectResponse;
 import mokindang.jubging.project_backend.web.argumentresolver.Login;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
 import javax.validation.Valid;
@@ -34,4 +39,24 @@ public interface CertificationBoardControllerSwagger {
     })
     @PostMapping
     ResponseEntity<CertificationBoardIdResponse> write(@Parameter(hidden = true) @Login Long memberId, @Valid @ModelAttribute final CertificationBoardCreationRequest certificationBoardCreationRequest);
+
+    @Operation(summary = "인증 게시글 조회", parameters = {
+            @Parameter(name = "boardId", description = "Board 의 id", in = ParameterIn.PATH),
+            @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true)}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "글 조회"),
+            @ApiResponse(responseCode = "400", description = "존재하지 않는 게시글 조회 ",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    }
+    )
+    @GetMapping("/{boardId}")
+    ResponseEntity<CertificationBoardSelectionResponse> selectBoard(@Parameter(hidden = true) @Login Long memberId, @PathVariable final Long boardId);
+
+    @Operation(summary = "전체 게시글 리스트 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "전체 게시글 리스트 조회 완료"),
+    })
+    @GetMapping
+    ResponseEntity<MultiCertificationBoardSelectResponse> selectBoards(final Pageable pageable);
 }

--- a/src/main/java/mokindang/jubging/project_backend/domain/board/certificationboard/CertificationBoard.java
+++ b/src/main/java/mokindang/jubging/project_backend/domain/board/certificationboard/CertificationBoard.java
@@ -5,10 +5,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mokindang.jubging.project_backend.domain.board.recruitment.vo.ContentBody;
 import mokindang.jubging.project_backend.domain.board.recruitment.vo.Title;
+import mokindang.jubging.project_backend.domain.image.Image;
 import mokindang.jubging.project_backend.domain.member.Member;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 @Getter
@@ -37,6 +40,9 @@ public class CertificationBoard {
     @Embedded
     private ContentBody contentBody;
 
+    @OneToMany(mappedBy = "certificationBoard")
+    private List<Image> images = new ArrayList<>();
+
     public CertificationBoard(final LocalDateTime createdDateTime, final LocalDateTime modifiedTIme,
                               final Member writer, final String title, final String contentBody) {
         this.createdDateTime = createdDateTime;
@@ -44,6 +50,28 @@ public class CertificationBoard {
         this.writer = writer;
         this.title = new Title(title);
         this.contentBody = new ContentBody(contentBody);
+    }
+
+    public boolean isSameWriterId(final Long memberId) {
+        return writer.getId()
+                .equals(memberId);
+    }
+
+    public String getWriterProfileImageUrl() {
+        return writer.getProfileImage()
+                .getProfileImageUrl();
+    }
+
+    public String getWriterAlias() {
+        return writer.getAlias();
+    }
+
+    public String getFirstFourDigitsOfWriterEmail() {
+        return writer.getFirstFourDigitsOfWriterEmail();
+    }
+
+    public String getMainImageUrl(){
+        return images.get(0).getFilePath();
     }
 
     @Override

--- a/src/main/java/mokindang/jubging/project_backend/repository/board/certificationboard/CertificationBoardRepository.java
+++ b/src/main/java/mokindang/jubging/project_backend/repository/board/certificationboard/CertificationBoardRepository.java
@@ -1,8 +1,15 @@
 package mokindang.jubging.project_backend.repository.board.certificationboard;
 
 import mokindang.jubging.project_backend.domain.board.certificationboard.CertificationBoard;
+import org.hibernate.annotations.BatchSize;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CertificationBoardRepository extends JpaRepository<CertificationBoard, Long> {
 
+    @BatchSize(size = 1000)
+    @Query("SELECT c FROM CertificationBoard c")
+    Slice<CertificationBoard> selectBoards(final Pageable pageable);
 }

--- a/src/main/java/mokindang/jubging/project_backend/repository/image/ImageRepository.java
+++ b/src/main/java/mokindang/jubging/project_backend/repository/image/ImageRepository.java
@@ -1,7 +1,13 @@
 package mokindang.jubging.project_backend.repository.image;
 
+import mokindang.jubging.project_backend.domain.board.certificationboard.CertificationBoard;
 import mokindang.jubging.project_backend.domain.image.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface ImageRepository extends JpaRepository<Image, Long> {
+
+    Optional<List<Image>> findByCertificationBoard(CertificationBoard certificationBoard);
 }

--- a/src/main/java/mokindang/jubging/project_backend/service/board/certificationboard/CertificationBoardService.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/board/certificationboard/CertificationBoardService.java
@@ -1,18 +1,28 @@
 package mokindang.jubging.project_backend.service.board.certificationboard;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import mokindang.jubging.project_backend.domain.board.certificationboard.CertificationBoard;
 import mokindang.jubging.project_backend.domain.member.Member;
 import mokindang.jubging.project_backend.repository.board.certificationboard.CertificationBoardRepository;
 import mokindang.jubging.project_backend.service.board.certificationboard.request.CertificationBoardCreationRequest;
 import mokindang.jubging.project_backend.service.board.certificationboard.response.CertificationBoardIdResponse;
+import mokindang.jubging.project_backend.service.board.certificationboard.response.CertificationBoardResponse;
+import mokindang.jubging.project_backend.service.board.certificationboard.response.CertificationBoardSelectionResponse;
+import mokindang.jubging.project_backend.service.board.certificationboard.response.MultiCertificationBoardSelectResponse;
 import mokindang.jubging.project_backend.service.file.FileService;
+import mokindang.jubging.project_backend.service.image.ImageService;
 import mokindang.jubging.project_backend.service.member.MemberService;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -20,15 +30,35 @@ public class CertificationBoardService {
 
     private final MemberService memberService;
     private final FileService fileService;
+    private final ImageService imageService;
     private final CertificationBoardRepository certificationBoardRepository;
 
     @Transactional
     public CertificationBoardIdResponse write(final Long memberId, final CertificationBoardCreationRequest certificationBoardCreationRequest) {
         Member writer = memberService.findByMemberId(memberId);
         LocalDateTime now = LocalDateTime.now();
-        CertificationBoard certificationBoard = new CertificationBoard(now, now, writer, certificationBoardCreationRequest.getTitle(), certificationBoardCreationRequest.getContent());
+        CertificationBoard certificationBoard = new CertificationBoard(now, now, writer, certificationBoardCreationRequest.getTitle(), certificationBoardCreationRequest.getContentBody());
         CertificationBoard savedCertificationBoard = certificationBoardRepository.save(certificationBoard);
         fileService.uploadFiles(certificationBoardCreationRequest.getFiles(), writer, savedCertificationBoard);
         return new CertificationBoardIdResponse(savedCertificationBoard.getId());
+    }
+
+    public CertificationBoardSelectionResponse select(final Long memberId, final Long boardId) {
+        CertificationBoard certificationBoard = findById(boardId);
+        List<String> findImagesUrl = imageService.findImagesUrl(certificationBoard);
+        return new CertificationBoardSelectionResponse(certificationBoard, findImagesUrl, certificationBoard.isSameWriterId(memberId));
+    }
+
+    private CertificationBoard findById(final Long boardId) {
+        return certificationBoardRepository.findById(boardId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시물입니다."));
+    }
+
+    public MultiCertificationBoardSelectResponse selectAllBoards(final Pageable pageable) {
+        Slice<CertificationBoard> certificationBoards = certificationBoardRepository.selectBoards(pageable);
+        List<CertificationBoardResponse> certificationBoardResponses = certificationBoards.stream()
+                .map(CertificationBoardResponse::new)
+                .collect(Collectors.toUnmodifiableList());
+        return new MultiCertificationBoardSelectResponse(certificationBoardResponses, certificationBoards.hasNext());
     }
 }

--- a/src/main/java/mokindang/jubging/project_backend/service/board/certificationboard/request/CertificationBoardCreationRequest.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/board/certificationboard/request/CertificationBoardCreationRequest.java
@@ -18,7 +18,7 @@ public class CertificationBoardCreationRequest {
 
     @NotNull
     @NotBlank
-    private final String content;
+    private final String contentBody;
 
     private final List<MultipartFile> files;
 }

--- a/src/main/java/mokindang/jubging/project_backend/service/board/certificationboard/response/CertificationBoardResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/board/certificationboard/response/CertificationBoardResponse.java
@@ -1,0 +1,42 @@
+package mokindang.jubging.project_backend.service.board.certificationboard.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import mokindang.jubging.project_backend.domain.board.certificationboard.CertificationBoard;
+
+@Getter
+public class CertificationBoardResponse {
+
+    @Schema(description = "인증 게시글 번호", example = "1")
+    private final Long boardId;
+
+    @Schema(description = "인증 게시글 제목", example = "예시 제목 입니다.")
+    private final String title;
+
+    @Schema(description = "인증 게시글 본문", example = "게시글 본문 입니다.")
+    private final String contentBody;
+
+    @Schema(description = "작성자", example = "작성자닉네임")
+    private final String writerAlias;
+
+    @Schema(description = "작성자 프로필 url", example = "https://example-profile-image.png")
+    private final String writerProfileUrl;
+
+    @Schema(description = "인증 게시글 작성자의 이메일 앞 4글자", example = "test")
+    private final String firstFourLettersOfEmail;
+
+    @Schema(description = "인증 게시글의 메인 이미지 url", example = "https://example-main-image.png")
+    private final String mainImageUrl;
+
+    public CertificationBoardResponse(final CertificationBoard certificationBoard) {
+        this.boardId = certificationBoard.getId();
+        this.title = certificationBoard.getTitle()
+                .getValue();
+        this.contentBody = certificationBoard.getContentBody()
+                .getValue();
+        this.writerAlias = certificationBoard.getWriterAlias();
+        this.writerProfileUrl = certificationBoard.getWriterProfileImageUrl();
+        this.firstFourLettersOfEmail = certificationBoard.getFirstFourDigitsOfWriterEmail();
+        this.mainImageUrl = certificationBoard.getMainImageUrl();
+    }
+}

--- a/src/main/java/mokindang/jubging/project_backend/service/board/certificationboard/response/CertificationBoardSelectionResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/board/certificationboard/response/CertificationBoardSelectionResponse.java
@@ -1,0 +1,57 @@
+package mokindang.jubging.project_backend.service.board.certificationboard.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import mokindang.jubging.project_backend.domain.board.certificationboard.CertificationBoard;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class CertificationBoardSelectionResponse {
+
+    @Schema(description = "게시글 번호", example = "1")
+    private final Long boardId;
+
+    @Schema(description = "인증 게시글 제목", example = "예시 제목 입니다.")
+    private final String title;
+
+    @Schema(description = "인증 게시글 본문", example = "게시글 본문 입니다.")
+    private final String contentBody;
+
+    @Schema(description = "인증 게시글 작성 일시")
+    private final LocalDateTime creatingDatetime;
+
+    @Schema(description = "인증 게시글 마지막 수정일")
+    private final LocalDateTime modifiedTime;
+
+    @Schema(description = "인증 작성자", example = "작성자닉네임")
+    private final String writerAlias;
+
+    @Schema(description = "인증 게시글 작성자의 이메일 앞 4글자", example = "test")
+    private final String firstFourLettersOfEmail;
+
+    @Schema(description = "인증 게시글 작성자의 프로필 경로", example = "https://example-profile-image.png")
+    private final String writerProfileImageUrl;
+
+    @Schema(description = "인증 게시글 이미지")
+    private final List<String> certificationBoardImagesUrl;
+
+    @Schema(description = "인증 게시글 조회 회원이, 작성자인지에 대한 정보", allowableValues = {"true", "false"})
+    private final boolean mine;
+
+    public CertificationBoardSelectionResponse(final CertificationBoard board, final List<String> findImagesUrl, final boolean mine) {
+        this.boardId = board.getId();
+        this.title = board.getTitle()
+                .getValue();
+        this.contentBody = board.getContentBody()
+                .getValue();
+        this.creatingDatetime = board.getCreatedDateTime();
+        this.modifiedTime = board.getModifiedTIme();
+        this.writerAlias = board.getWriterAlias();
+        this.firstFourLettersOfEmail = board.getFirstFourDigitsOfWriterEmail();
+        this.writerProfileImageUrl = board.getWriterProfileImageUrl();
+        this.certificationBoardImagesUrl = findImagesUrl;
+        this.mine = mine;
+    }
+}

--- a/src/main/java/mokindang/jubging/project_backend/service/board/certificationboard/response/MultiCertificationBoardSelectResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/board/certificationboard/response/MultiCertificationBoardSelectResponse.java
@@ -1,0 +1,18 @@
+package mokindang.jubging.project_backend.service.board.certificationboard.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class MultiCertificationBoardSelectResponse {
+
+    @Schema(description = "조회된 요약 게시글 목록")
+    private final List<CertificationBoardResponse> boards;
+
+    @Schema(description = "다음 게시글 존재 여부")
+    private final boolean hasNext;
+}

--- a/src/main/java/mokindang/jubging/project_backend/service/file/FileService.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/file/FileService.java
@@ -63,8 +63,7 @@ public class FileService {
             uploadFileUrl = uploadToS3(multipartFile, uploadFilePath, uploadFileName, uploadFileUrl, objectMetadata);
 
             log.info("memberId = {}, alias = {} 의 boardId = {} 인증 게시판 이미지 {} 업로드", member.getId(), member.getAlias(), certificationBoard.getId(), uploadFileName);
-            FileResponse fileResponse = new FileResponse(uploadFileUrl, uploadFileName);
-            imageRepository.save(new Image(certificationBoard, fileResponse.getUploadFileName(), fileResponse.getUploadFileUrl()));
+            imageRepository.save(new Image(certificationBoard, uploadFileName, uploadFileUrl));
         }
     }
 
@@ -108,7 +107,7 @@ public class FileService {
         log.info("memberId = {}, alias = {} 의 이전 프로필 이미지 {} 삭제", member.getId(), member.getAlias(), member.getProfileImage().getProfileImageName());
     }
 
-    private static boolean checkNameDefault(String uploadFileName) {
+    private boolean checkNameDefault(String uploadFileName) {
         if(uploadFileName.equals(DEFAULT_PROFILE_IMAGE_NAME)){
             log.info("기본이미지로 삭제되지 않았습니다.");
             return true;

--- a/src/main/java/mokindang/jubging/project_backend/service/image/ImageService.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/image/ImageService.java
@@ -1,0 +1,30 @@
+package mokindang.jubging.project_backend.service.image;
+
+import lombok.RequiredArgsConstructor;
+import mokindang.jubging.project_backend.domain.board.certificationboard.CertificationBoard;
+import mokindang.jubging.project_backend.domain.image.Image;
+import mokindang.jubging.project_backend.repository.image.ImageRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final ImageRepository imageRepository;
+
+    public List<String> findImagesUrl(final CertificationBoard board) {
+        List<String> imagesUrl = new ArrayList<>();
+        List<Image> images = imageRepository.findByCertificationBoard(board)
+                .orElseThrow(() -> new IllegalArgumentException("인증 게시판 id로 저장된 이미지가 존재하지 않습니다."));
+
+        for (Image image : images) {
+            imagesUrl.add(image.getFilePath());
+        }
+        return imagesUrl;
+    }
+}

--- a/src/main/java/mokindang/jubging/project_backend/service/image/ImageService.java
+++ b/src/main/java/mokindang/jubging/project_backend/service/image/ImageService.java
@@ -21,10 +21,13 @@ public class ImageService {
         List<String> imagesUrl = new ArrayList<>();
         List<Image> images = imageRepository.findByCertificationBoard(board)
                 .orElseThrow(() -> new IllegalArgumentException("인증 게시판 id로 저장된 이미지가 존재하지 않습니다."));
+        setImagesUrl(imagesUrl, images);
+        return imagesUrl;
+    }
 
+    private void setImagesUrl(List<String> imagesUrl, List<Image> images) {
         for (Image image : images) {
             imagesUrl.add(image.getFilePath());
         }
-        return imagesUrl;
     }
 }


### PR DESCRIPTION
# Feature/#284/인증게시글 조회 구현

### 이슈 번호 : #284 

## 변경 사항
-    인증게시글 상세 조회 구현
-    인증게시글 전체 조회 구현
-    인증게시글과 이미지 엔티티 다대일 양뱡향 구현
      -> 인증게시글에서 이미지를 찾아야 하는 로직이 필요해 추가하였음

## 그 외
- 

## 질문 사항
- 
