### PR TITLE
Refactor/#305/댓글 작성 api 리팩토링

### DIFF
--- a/src/main/java/mokindang/jubging/project_backend/certification_board/domain/CertificationBoard.java
+++ b/src/main/java/mokindang/jubging/project_backend/certification_board/domain/CertificationBoard.java
@@ -3,11 +3,12 @@ package mokindang.jubging.project_backend.certification_board.domain;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import mokindang.jubging.project_backend.recruitment_board.domain.vo.ContentBody;
-import mokindang.jubging.project_backend.recruitment_board.domain.vo.Title;
+import mokindang.jubging.project_backend.comment.domain.Comment;
+import mokindang.jubging.project_backend.exception.custom.ForbiddenException;
 import mokindang.jubging.project_backend.image.domain.Image;
 import mokindang.jubging.project_backend.member.domain.Member;
-import mokindang.jubging.project_backend.exception.custom.ForbiddenException;
+import mokindang.jubging.project_backend.recruitment_board.domain.vo.ContentBody;
+import mokindang.jubging.project_backend.recruitment_board.domain.vo.Title;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -44,6 +45,9 @@ public class CertificationBoard {
     @OneToMany(mappedBy = "certificationBoard")
     private List<Image> images = new ArrayList<>();
 
+    @OneToMany(mappedBy = "certificationBoard", cascade = CascadeType.REMOVE)
+    List<Comment> comments = new ArrayList<>();
+
     public CertificationBoard(final LocalDateTime createdDateTime, final LocalDateTime modifiedTIme,
                               final Member writer, final String title, final String contentBody) {
         this.createdDateTime = createdDateTime;
@@ -71,7 +75,7 @@ public class CertificationBoard {
         return writer.getFirstFourDigitsOfWriterEmail();
     }
 
-    public String getMainImageUrl(){
+    public String getMainImageUrl() {
         return images.get(0).getFilePath();
     }
 
@@ -86,6 +90,10 @@ public class CertificationBoard {
         this.modifiedTIme = LocalDateTime.now();
         this.title = new Title(titleValue);
         this.contentBody = new ContentBody(contentBody);
+    }
+
+    public void addComment(final Comment comment) {
+        this.comments.add(comment);
     }
 
     @Override

--- a/src/main/java/mokindang/jubging/project_backend/certification_board/service/CertificationBoardService.java
+++ b/src/main/java/mokindang/jubging/project_backend/certification_board/service/CertificationBoardService.java
@@ -54,7 +54,7 @@ public class CertificationBoardService {
         return new CertificationBoardSelectionResponse(certificationBoard, findImagesUrl, certificationBoard.isSameWriterId(memberId));
     }
 
-    private CertificationBoard findById(final Long boardId) {
+    public CertificationBoard findById(final Long boardId) {
         return certificationBoardRepository.findById(boardId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시물입니다."));
     }

--- a/src/main/java/mokindang/jubging/project_backend/comment/controller/CommentController.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/controller/CommentController.java
@@ -2,9 +2,10 @@ package mokindang.jubging.project_backend.comment.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import mokindang.jubging.project_backend.comment.service.BoardType;
 import mokindang.jubging.project_backend.comment.service.CommentService;
 import mokindang.jubging.project_backend.comment.service.request.CommentCreationRequest;
-import mokindang.jubging.project_backend.recruitment_board.service.response.RecruitmentBoardIdResponse;
+import mokindang.jubging.project_backend.comment.service.response.BoardIdResponse;
 import mokindang.jubging.project_backend.web.argumentresolver.Login;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,16 +17,18 @@ import javax.validation.Valid;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api")
-public class CommentController implements CommentControllerSwagger{
+public class CommentController implements CommentControllerSwagger {
 
     private final CommentService commentService;
 
-    @PostMapping("/recruitment-board/{boardId}/comments")
-    public ResponseEntity<RecruitmentBoardIdResponse> addCommentToRecruitmentBoard(@Login final Long memberId, @PathVariable final Long boardId,
-                                                                                   @Valid @RequestBody final CommentCreationRequest commentCreationRequest) {
+    @PostMapping("/{board-type}/{boardId}/comments")
+    public ResponseEntity<BoardIdResponse> addCommentToBoard(@Login final Long memberId,
+                                                             @PathVariable("board-type") final BoardType boardType,
+                                                             @PathVariable final Long boardId,
+                                                             @Valid @RequestBody final CommentCreationRequest commentCreationRequest) {
         log.info("memberId ={} 의 RecruitmentBoardId = {} 에 대한 댓글 작성 요청", memberId, boardId);
-        RecruitmentBoardIdResponse recruitmentBoardIdResponse = commentService.addCommentToRecruitmentBoard(memberId, boardId, commentCreationRequest);
+        BoardIdResponse boardIdResponse = commentService.addComment(memberId, boardType, boardId, commentCreationRequest);
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(recruitmentBoardIdResponse);
+                .body(boardIdResponse);
     }
 }

--- a/src/main/java/mokindang/jubging/project_backend/comment/controller/CommentControllerSwagger.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/controller/CommentControllerSwagger.java
@@ -8,9 +8,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import mokindang.jubging.project_backend.comment.service.BoardType;
 import mokindang.jubging.project_backend.comment.service.request.CommentCreationRequest;
+import mokindang.jubging.project_backend.comment.service.response.BoardIdResponse;
 import mokindang.jubging.project_backend.exception.ErrorResponse;
-import mokindang.jubging.project_backend.recruitment_board.service.response.RecruitmentBoardIdResponse;
 import mokindang.jubging.project_backend.web.argumentresolver.Login;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -33,9 +34,12 @@ public interface CommentControllerSwagger {
             @ApiResponse(responseCode = "201", description = "새 댓글 작성"),
             @ApiResponse(responseCode = "400", description = "유효하지 않은 유저 \t\n" +
                     "존재하지 않는 게시글 \t\n" +
-                    "유효하지 않은 댓글 길이 \t\n", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    "유효하지 않은 댓글 길이 \t\n" +
+                    "존재하지 않는 게시판에 대한 접근 \t\n",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
-    @PostMapping("/recruitment-board/{boardId}/comments")
-    ResponseEntity<RecruitmentBoardIdResponse> addCommentToRecruitmentBoard(@Login final Long memberId, @PathVariable final Long boardId,
-                                                                            @Valid @RequestBody final CommentCreationRequest commentCreationRequest);
+    @PostMapping("/{board-type}/{boardId}/comments")
+    ResponseEntity<BoardIdResponse> addCommentToBoard(@Login final Long memberId, @PathVariable("board-type") final BoardType boardType,
+                                                      @PathVariable final Long boardId,
+                                                      @Valid @RequestBody final CommentCreationRequest commentCreationRequest);
 }

--- a/src/main/java/mokindang/jubging/project_backend/comment/domain/Comment.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/domain/Comment.java
@@ -3,9 +3,10 @@ package mokindang.jubging.project_backend.comment.domain;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
+import mokindang.jubging.project_backend.certification_board.domain.CertificationBoard;
 import mokindang.jubging.project_backend.comment.domain.vo.CommentBody;
 import mokindang.jubging.project_backend.member.domain.Member;
+import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -38,13 +39,22 @@ public class Comment {
     @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE)
     private List<ReplyComment> replyComments = new ArrayList<>();
 
+    @ManyToOne
+    @JoinColumn(name = "certification_board_id")
+    private CertificationBoard certificationBoard;
+
+
     @Column(nullable = false)
     private LocalDateTime createdDateTime;
 
     @Column(nullable = false)
     private LocalDateTime lastModifiedDateTime;
 
-    public Comment(final RecruitmentBoard board, final String commentBody, final Member writer, final LocalDateTime now) {
+    public static Comment createOnRecruitmentBoardWith(final RecruitmentBoard board, final String commentBody, final Member writer, final LocalDateTime now) {
+        return new Comment(board, commentBody, writer, now);
+    }
+
+    private Comment(final RecruitmentBoard board, final String commentBody, final Member writer, final LocalDateTime now) {
         this.commentBody = new CommentBody(commentBody);
         this.writer = writer;
         this.createdDateTime = now;
@@ -55,6 +65,23 @@ public class Comment {
     private void setRecruitmentBoard(final RecruitmentBoard recruitmentBoard) {
         this.recruitmentBoard = recruitmentBoard;
         recruitmentBoard.addComment(this);
+    }
+
+    public static Comment createOnCertificationBoardWith(final CertificationBoard board, final String commentBody, final Member writer, final LocalDateTime now) {
+        return new Comment(board, commentBody, writer, now);
+    }
+
+    private Comment(final CertificationBoard board, final String commentBody, final Member writer, final LocalDateTime now) {
+        this.commentBody = new CommentBody(commentBody);
+        this.writer = writer;
+        this.createdDateTime = now;
+        this.lastModifiedDateTime = createdDateTime;
+        setCertificationBoard(board);
+    }
+
+    private void setCertificationBoard(final CertificationBoard certificationBoard) {
+        this.certificationBoard = certificationBoard;
+        certificationBoard.addComment(this);
     }
 
     public void modify(final String commentBody, final LocalDateTime now) {

--- a/src/main/java/mokindang/jubging/project_backend/comment/service/BoardType.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/service/BoardType.java
@@ -1,0 +1,21 @@
+package mokindang.jubging.project_backend.comment.service;
+
+import java.util.Arrays;
+
+public enum BoardType {
+
+    RECRUITMENT_BOARD("recruitment-board"), CERTIFICATION_BOARD("certification-board");
+
+    private final String value;
+
+    BoardType(final String value) {
+        this.value = value;
+    }
+
+    public static BoardType from(final String boardTypeValue) {
+        return Arrays.stream(values())
+                .filter(boardType -> boardTypeValue.equals(boardType.value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시판 타입 입니다."));
+    }
+}

--- a/src/main/java/mokindang/jubging/project_backend/comment/service/CommentService.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/service/CommentService.java
@@ -2,14 +2,16 @@ package mokindang.jubging.project_backend.comment.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import mokindang.jubging.project_backend.certification_board.domain.CertificationBoard;
+import mokindang.jubging.project_backend.certification_board.service.CertificationBoardService;
 import mokindang.jubging.project_backend.comment.domain.Comment;
 import mokindang.jubging.project_backend.comment.repository.CommentRepository;
 import mokindang.jubging.project_backend.comment.service.request.CommentCreationRequest;
+import mokindang.jubging.project_backend.comment.service.response.BoardIdResponse;
 import mokindang.jubging.project_backend.member.domain.Member;
 import mokindang.jubging.project_backend.member.service.MemberService;
 import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
 import mokindang.jubging.project_backend.recruitment_board.service.RecruitmentBoardService;
-import mokindang.jubging.project_backend.recruitment_board.service.response.RecruitmentBoardIdResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,16 +26,28 @@ public class CommentService {
 
     private final CommentRepository commentRepository;
     private final RecruitmentBoardService recruitmentBoardService;
+    private final CertificationBoardService certificationBoardService;
     private final MemberService memberService;
 
     @Transactional
-    public RecruitmentBoardIdResponse addCommentToRecruitmentBoard(final Long memberId, final Long boardId,
-                                                                   final CommentCreationRequest commentCreationRequest) {
+    public BoardIdResponse addComment(final Long memberId, final BoardType boardType, final Long boardId,
+                                      final CommentCreationRequest commentCreationRequest) {
         Member writer = memberService.findByMemberId(memberId);
-        RecruitmentBoard board = recruitmentBoardService.findById(boardId);
         LocalDateTime now = LocalDateTime.now();
-        Comment comment = new Comment(board, commentCreationRequest.getCommentBody(), writer, now);
-        commentRepository.save(comment);
-        return new RecruitmentBoardIdResponse(board.getId());
+
+        if (boardType.equals(BoardType.RECRUITMENT_BOARD)) {
+            RecruitmentBoard board = recruitmentBoardService.findById(boardId);
+            Comment comment = Comment.createOnRecruitmentBoardWith(board, commentCreationRequest.getCommentBody(), writer, now);
+            commentRepository.save(comment);
+            return new BoardIdResponse(boardId);
+        }
+
+        if (boardType.equals(BoardType.CERTIFICATION_BOARD)) {
+            CertificationBoard board = certificationBoardService.findById(boardId);
+            Comment comment = Comment.createOnCertificationBoardWith(board, commentCreationRequest.getCommentBody(), writer, now);
+            commentRepository.save(comment);
+            return new BoardIdResponse(boardId);
+        }
+        throw new IllegalArgumentException("존재 하지 않는 게시판에 대한 접근입니다.");
     }
 }

--- a/src/main/java/mokindang/jubging/project_backend/comment/service/response/BoardIdResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/service/response/BoardIdResponse.java
@@ -1,0 +1,15 @@
+package mokindang.jubging.project_backend.comment.service.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class BoardIdResponse {
+
+    @Schema(description = "게시글 id")
+    private Long boardId;
+}

--- a/src/main/java/mokindang/jubging/project_backend/web/config/BoardTypeConverterConfig.java
+++ b/src/main/java/mokindang/jubging/project_backend/web/config/BoardTypeConverterConfig.java
@@ -1,0 +1,15 @@
+package mokindang.jubging.project_backend.web.config;
+
+import mokindang.jubging.project_backend.web.converter.BoardTypeConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class BoardTypeConverterConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addFormatters(final FormatterRegistry registry) {
+        registry.addConverter(new BoardTypeConverter());
+    }
+}

--- a/src/main/java/mokindang/jubging/project_backend/web/converter/BoardTypeConverter.java
+++ b/src/main/java/mokindang/jubging/project_backend/web/converter/BoardTypeConverter.java
@@ -1,0 +1,12 @@
+package mokindang.jubging.project_backend.web.converter;
+
+import mokindang.jubging.project_backend.comment.service.BoardType;
+import org.springframework.core.convert.converter.Converter;
+
+public class BoardTypeConverter implements Converter<String, BoardType> {
+
+    @Override
+    public BoardType convert(final String boardType) {
+        return BoardType.from(boardType);
+    }
+}

--- a/src/test/java/mokindang/jubging/project_backend/comment/controller/CommentControllerTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/comment/controller/CommentControllerTest.java
@@ -1,10 +1,10 @@
 package mokindang.jubging.project_backend.comment.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import mokindang.jubging.project_backend.comment.service.BoardType;
 import mokindang.jubging.project_backend.comment.service.CommentService;
 import mokindang.jubging.project_backend.comment.service.request.CommentCreationRequest;
-import mokindang.jubging.project_backend.recruitment_board.service.RecruitmentBoardService;
-import mokindang.jubging.project_backend.recruitment_board.service.response.RecruitmentBoardIdResponse;
+import mokindang.jubging.project_backend.comment.service.response.BoardIdResponse;
 import mokindang.jubging.project_backend.web.jwt.TokenManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,9 +32,6 @@ class CommentControllerTest {
     private ObjectMapper objectMapper;
 
     @MockBean
-    private RecruitmentBoardService recruitmentBoardService;
-
-    @MockBean
     private CommentService commentService;
 
     @MockBean
@@ -44,12 +41,14 @@ class CommentControllerTest {
     @DisplayName("입력받은 boardId 에 해당하는 recruitmentBoard 에 새 댓글을 추가한다.")
     void addCommentToRecruitmentBoard() throws Exception {
         //given
-        when(commentService.addCommentToRecruitmentBoard(anyLong(), anyLong(), any(CommentCreationRequest.class))).thenReturn(new RecruitmentBoardIdResponse(1L));
+        when(commentService.addComment(anyLong(), any(BoardType.class), anyLong(), any(CommentCreationRequest.class)))
+                .thenReturn(new BoardIdResponse(1L));
 
         CommentCreationRequest commentCreationRequest = new CommentCreationRequest("댓글 예시입니다.");
 
         //when
-        ResultActions actual = mockMvc.perform(post("/api/recruitment-board/{boardId}/comments", 1L)
+        ResultActions actual = mockMvc.perform(post("/api/{board-type}/{boardId}/comments",
+                "recruitment-board", 1L)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(commentCreationRequest)));
 

--- a/src/test/java/mokindang/jubging/project_backend/comment/service/CommentServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/comment/service/CommentServiceTest.java
@@ -44,7 +44,7 @@ class CommentServiceTest {
         CommentCreationRequest commentCreateRequest = createCommentCreateRequest();
 
         //when
-        commentService.addCommentToRecruitmentBoard(1L, 1L, commentCreateRequest);
+        commentService.addComment(1L, BoardType.RECRUITMENT_BOARD,1L, commentCreateRequest);
 
         //then
         verify(commentRepository, times(1)).save(any());

--- a/src/test/java/mokindang/jubging/project_backend/domain/comment/CommentTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/domain/comment/CommentTest.java
@@ -1,8 +1,8 @@
 package mokindang.jubging.project_backend.domain.comment;
 
 import mokindang.jubging.project_backend.comment.domain.Comment;
-import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
 import mokindang.jubging.project_backend.member.domain.Member;
+import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,7 +24,7 @@ class CommentTest {
         String commentBodyValue = "안녕하세요.";
 
         //when, then
-        assertThatCode(() -> new Comment(recruitmentBoard, commentBodyValue, writer, now)).doesNotThrowAnyException();
+        assertThatCode(() -> Comment.createOnRecruitmentBoardWith(recruitmentBoard, commentBodyValue, writer, now)).doesNotThrowAnyException();
     }
 
     private RecruitmentBoard createRecruitmentBoard() {
@@ -46,7 +46,7 @@ class CommentTest {
         String commentBodyValue = "안녕하세요.";
 
         //when
-        Comment comment = new Comment(recruitmentBoard, commentBodyValue, writer, now);
+        Comment comment = Comment.createOnRecruitmentBoardWith(recruitmentBoard, commentBodyValue, writer, now);
 
         //then
         softly.assertThat(comment.getCommentBody().getBody()).isEqualTo("안녕하세요.");
@@ -65,7 +65,7 @@ class CommentTest {
         LocalDateTime createdTime = LocalDateTime.of(2023, 4, 8, 16, 48);
         Member writer = new Member("test@email.com", "test");
         String commentBodyValue = "안녕하세요.";
-        Comment comment = new Comment(recruitmentBoard, commentBodyValue, writer, createdTime);
+        Comment comment = Comment.createOnRecruitmentBoardWith(recruitmentBoard, commentBodyValue, writer, createdTime);
         String newCommentBody = "하이~~";
         LocalDateTime now = LocalDateTime.of(2023, 5, 9, 11, 11, 11);
 


### PR DESCRIPTION
# Refactor/#305/댓글 작성 api 리팩토링

### 이슈 번호 : #305

## 변경 사항
-   댓글 작성 api 변경
    - 게시판의 종류를 pathVariable 로 받아 댓글을 작성하도록함.
    - 구인 게시판, 인증 게시판에 대한 댓글을 유동적으로 받을 수 있도록 변경
-  인증 게시판 댓글 작성 기능이 추가 됨에 따라서, CertificationBoard 와 Comment 엔티티의 연관관계를 설정해줌.   

## 그 외
- BoardType 을 추가하여 api 요청시 pathVariable 에 제대로 된 값이 들어왔는지 확인 할 수 있도록 함.

## 질문 사항
- 
