### PR TITLE
Feature/#311/댓글 조회 api 구현

### DIFF
--- a/src/main/java/mokindang/jubging/project_backend/comment/controller/CommentController.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/controller/CommentController.java
@@ -6,6 +6,7 @@ import mokindang.jubging.project_backend.comment.service.BoardType;
 import mokindang.jubging.project_backend.comment.service.CommentService;
 import mokindang.jubging.project_backend.comment.service.request.CommentCreationRequest;
 import mokindang.jubging.project_backend.comment.service.response.BoardIdResponse;
+import mokindang.jubging.project_backend.comment.service.response.MultiCommentSelectionResponse;
 import mokindang.jubging.project_backend.web.argumentresolver.Login;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,9 +27,19 @@ public class CommentController implements CommentControllerSwagger {
                                                              @PathVariable("board-type") final BoardType boardType,
                                                              @PathVariable final Long boardId,
                                                              @Valid @RequestBody final CommentCreationRequest commentCreationRequest) {
-        log.info("memberId ={} 의 RecruitmentBoardId = {} 에 대한 댓글 작성 요청", memberId, boardId);
+        log.info("memberId ={} 의 게시판 {} BoardId = {} 에 대한 댓글 작성 요청", memberId, boardType.toString(), boardId);
         BoardIdResponse boardIdResponse = commentService.addComment(memberId, boardType, boardId, commentCreationRequest);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(boardIdResponse);
+    }
+
+    @GetMapping("/{board-type}/{boardId}/comments")
+    public ResponseEntity<MultiCommentSelectionResponse> selectComments(@Login final Long memberId,
+                                                                        @PathVariable("board-type") final BoardType boardType,
+                                                                        @PathVariable final Long boardId) {
+        log.info("memberId = {} 의 게시판 {} boardId = {} 에 대한 댓글 조회 요청", memberId, boardType.toString(), boardId);
+        MultiCommentSelectionResponse multiCommentSelectionResponse = commentService.selectComments(memberId, boardType, boardId);
+        return ResponseEntity.ok()
+                .body(multiCommentSelectionResponse);
     }
 }

--- a/src/main/java/mokindang/jubging/project_backend/comment/controller/CommentControllerSwagger.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/controller/CommentControllerSwagger.java
@@ -11,9 +11,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import mokindang.jubging.project_backend.comment.service.BoardType;
 import mokindang.jubging.project_backend.comment.service.request.CommentCreationRequest;
 import mokindang.jubging.project_backend.comment.service.response.BoardIdResponse;
+import mokindang.jubging.project_backend.comment.service.response.MultiCommentSelectionResponse;
 import mokindang.jubging.project_backend.exception.ErrorResponse;
 import mokindang.jubging.project_backend.web.argumentresolver.Login;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,20 +28,39 @@ import static org.springframework.http.HttpHeaders.SET_COOKIE;
 @Tag(name = "댓글 서비스", description = "댓글 관련 api")
 public interface CommentControllerSwagger {
 
-    @Operation(summary = "구인 게시판에 새 댓글 작성", parameters = {
+    @Operation(summary = "게시판에 새 댓글 작성", parameters = {
             @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true),
-            @Parameter(name = SET_COOKIE, description = "refreshToken", in = ParameterIn.COOKIE, required = true)}
+            @Parameter(name = SET_COOKIE, description = "refreshToken", in = ParameterIn.COOKIE, required = true)
+    }
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "새 댓글 작성"),
-            @ApiResponse(responseCode = "400", description = "유효하지 않은 유저 \t\n" +
+            @ApiResponse(responseCode = "400", description = "존재하지 않은 유저 \t\n" +
                     "존재하지 않는 게시글 \t\n" +
                     "유효하지 않은 댓글 길이 \t\n" +
                     "존재하지 않는 게시판에 대한 접근 \t\n",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
     @PostMapping("/{board-type}/{boardId}/comments")
-    ResponseEntity<BoardIdResponse> addCommentToBoard(@Login final Long memberId, @PathVariable("board-type") final BoardType boardType,
+    ResponseEntity<BoardIdResponse> addCommentToBoard(@Login final Long memberId,
+                                                      @Parameter(hidden = true) @PathVariable("board-type") final BoardType boardType,
                                                       @PathVariable final Long boardId,
                                                       @Valid @RequestBody final CommentCreationRequest commentCreationRequest);
+
+    @Operation(summary = "게시판의 댓글 목록 조회", parameters = {
+            @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true),
+            @Parameter(name = SET_COOKIE, description = "refreshToken", in = ParameterIn.COOKIE, required = true)
+    }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "댓글 리스트 조회 완료"),
+            @ApiResponse(responseCode = "400", description =
+                    "존재하지 않는 댓글에 대한 접근 \t\n" +
+                            "유효하지 않은 게시글 종류에 대한 접근 \t\n",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @GetMapping("/{board-type}/{boardId}/comments")
+    ResponseEntity<MultiCommentSelectionResponse> selectComments(@Login final Long memberId,
+                                                                 @PathVariable("board-type") final BoardType boardType,
+                                                                 @PathVariable final Long boardId);
 }

--- a/src/main/java/mokindang/jubging/project_backend/comment/domain/Comment.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/domain/Comment.java
@@ -89,6 +89,23 @@ public class Comment {
         this.lastModifiedDateTime = now;
     }
 
+    public boolean wasEdited() {
+        return lastModifiedDateTime.isAfter(createdDateTime);
+    }
+
+    public String getWriterProfileImageUrl() {
+        return writer.getProfileImage()
+                .getProfileImageUrl();
+    }
+
+    public String getWriterAlias() {
+        return writer.getAlias();
+    }
+
+    public String getFirstFourDigitsOfWriterEmail() {
+        return writer.getFirstFourDigitsOfWriterEmail();
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;

--- a/src/main/java/mokindang/jubging/project_backend/comment/domain/Comment.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/domain/Comment.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mokindang.jubging.project_backend.certification_board.domain.CertificationBoard;
 import mokindang.jubging.project_backend.comment.domain.vo.CommentBody;
+import mokindang.jubging.project_backend.exception.custom.ForbiddenException;
 import mokindang.jubging.project_backend.member.domain.Member;
 import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
 
@@ -84,9 +85,21 @@ public class Comment {
         certificationBoard.addComment(this);
     }
 
-    public void modify(final String commentBody, final LocalDateTime now) {
+    public void modify(final Long memberId,final String commentBody, final LocalDateTime now) {
+        validatePermission(memberId);
         this.commentBody = new CommentBody(commentBody);
         this.lastModifiedDateTime = now;
+    }
+
+    public boolean isSameWriterId(final Long memberId) {
+        return writer.getId()
+                .equals(memberId);
+    }
+
+    public void validatePermission(final Long memberId) {
+        if (!isSameWriterId(memberId)) {
+            throw new ForbiddenException("작성자 권한이 없습니다.");
+        }
     }
 
     public boolean wasEdited() {

--- a/src/main/java/mokindang/jubging/project_backend/comment/repository/CommentRepository.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/repository/CommentRepository.java
@@ -3,5 +3,11 @@ package mokindang.jubging.project_backend.comment.repository;
 import mokindang.jubging.project_backend.comment.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment,Long> {
+
+    List<Comment> findCommentsByRecruitmentBoardId(final Long boardId);
+
+    List<Comment> findCommentsByCertificationBoardId(final Long boardId);
 }

--- a/src/main/java/mokindang/jubging/project_backend/comment/service/CommentService.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/service/CommentService.java
@@ -8,6 +8,8 @@ import mokindang.jubging.project_backend.comment.domain.Comment;
 import mokindang.jubging.project_backend.comment.repository.CommentRepository;
 import mokindang.jubging.project_backend.comment.service.request.CommentCreationRequest;
 import mokindang.jubging.project_backend.comment.service.response.BoardIdResponse;
+import mokindang.jubging.project_backend.comment.service.response.CommentSelectionResponse;
+import mokindang.jubging.project_backend.comment.service.response.MultiCommentSelectionResponse;
 import mokindang.jubging.project_backend.member.domain.Member;
 import mokindang.jubging.project_backend.member.service.MemberService;
 import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
@@ -16,6 +18,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 
 @Slf4j
@@ -49,5 +53,25 @@ public class CommentService {
             return new BoardIdResponse(boardId);
         }
         throw new IllegalArgumentException("존재 하지 않는 게시판에 대한 접근입니다.");
+    }
+
+    @Transactional
+    public MultiCommentSelectionResponse selectComments(final Long memberId, final BoardType boardType, final Long boardId) {
+        if (boardType.equals(BoardType.RECRUITMENT_BOARD)) {
+            List<Comment> commentsByRecruitmentBoard = commentRepository.findCommentsByRecruitmentBoard(boardId);
+            return new MultiCommentSelectionResponse(convertToCommentSelectionResponse(memberId, commentsByRecruitmentBoard));
+        }
+
+        if (boardType.equals(BoardType.CERTIFICATION_BOARD)) {
+            List<Comment> commentsByCertificationBoard = commentRepository.findCommentsByCertificationBoard(boardId);
+            return new MultiCommentSelectionResponse(convertToCommentSelectionResponse(memberId, commentsByCertificationBoard));
+        }
+        throw new IllegalArgumentException("존재 하지 않는 게시판에 대한 접근입니다.");
+    }
+
+    private List<CommentSelectionResponse> convertToCommentSelectionResponse(final Long memberId, final List<Comment> commentsByRecruitmentBoard) {
+        return commentsByRecruitmentBoard.stream()
+                .map(comment -> new CommentSelectionResponse(comment, memberId))
+                .collect(Collectors.toUnmodifiableList());
     }
 }

--- a/src/main/java/mokindang/jubging/project_backend/comment/service/CommentService.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/service/CommentService.java
@@ -58,12 +58,12 @@ public class CommentService {
     @Transactional
     public MultiCommentSelectionResponse selectComments(final Long memberId, final BoardType boardType, final Long boardId) {
         if (boardType.equals(BoardType.RECRUITMENT_BOARD)) {
-            List<Comment> commentsByRecruitmentBoard = commentRepository.findCommentsByRecruitmentBoard(boardId);
+            List<Comment> commentsByRecruitmentBoard = commentRepository.findCommentsByRecruitmentBoardId(boardId);
             return new MultiCommentSelectionResponse(convertToCommentSelectionResponse(memberId, commentsByRecruitmentBoard));
         }
 
         if (boardType.equals(BoardType.CERTIFICATION_BOARD)) {
-            List<Comment> commentsByCertificationBoard = commentRepository.findCommentsByCertificationBoard(boardId);
+            List<Comment> commentsByCertificationBoard = commentRepository.findCommentsByCertificationBoardId(boardId);
             return new MultiCommentSelectionResponse(convertToCommentSelectionResponse(memberId, commentsByCertificationBoard));
         }
         throw new IllegalArgumentException("존재 하지 않는 게시판에 대한 접근입니다.");

--- a/src/main/java/mokindang/jubging/project_backend/comment/service/response/BoardIdResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/service/response/BoardIdResponse.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class BoardIdResponse {
 
-    @Schema(description = "게시글 id")
+    @Schema(description = "게시글 id", example = "1")
     private Long boardId;
 }

--- a/src/main/java/mokindang/jubging/project_backend/comment/service/response/CommentSelectionResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/service/response/CommentSelectionResponse.java
@@ -1,0 +1,48 @@
+package mokindang.jubging.project_backend.comment.service.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import mokindang.jubging.project_backend.comment.domain.Comment;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CommentSelectionResponse {
+
+    @Schema(description = "댓글 id")
+    private final Long commentId;
+
+    @Schema(description = "댓글 본문", example = "댓글 본문입니다.")
+    private final String commentBody;
+
+    @Schema(description = "댓글 작성 일시")
+    private final LocalDateTime createdDatetime;
+
+    @Schema(description = "작성자", example = "작성자닉네임")
+    private final String writerAlias;
+
+    @Schema(description = "게시글 수정 여부")
+    private final boolean edited;
+
+    @Schema(description = "게시글 작성자의 이메일 앞 4글자")
+    private final String firstFourLettersOfEmail;
+
+    @Schema(description = "게시글 작성자의 프로필 경로")
+    private final String writerProfileImageUrl;
+
+    @Schema(description = "게시글 조회 회원이, 작성자인지에 대한 정보", allowableValues = {"true", "false"})
+    private final boolean mine;
+
+
+    public CommentSelectionResponse(final Comment comment, final Long memberId) {
+        this.commentId = comment.getId();
+        this.commentBody = comment.getCommentBody()
+                .getBody();
+        this.createdDatetime = comment.getCreatedDateTime();
+        this.writerAlias = comment.getWriterAlias();
+        this.edited = comment.wasEdited();
+        this.firstFourLettersOfEmail = comment.getFirstFourDigitsOfWriterEmail();
+        this.writerProfileImageUrl = comment.getWriterProfileImageUrl();
+        this.mine = comment.isSameWriterId(memberId);
+    }
+}

--- a/src/main/java/mokindang/jubging/project_backend/comment/service/response/MultiCommentSelectionResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/service/response/MultiCommentSelectionResponse.java
@@ -3,12 +3,10 @@ package mokindang.jubging.project_backend.comment.service.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
 public class MultiCommentSelectionResponse {
 

--- a/src/main/java/mokindang/jubging/project_backend/comment/service/response/MultiCommentSelectionResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/service/response/MultiCommentSelectionResponse.java
@@ -1,0 +1,17 @@
+package mokindang.jubging.project_backend.comment.service.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MultiCommentSelectionResponse {
+
+    @Schema(description = "댓글 리스트")
+    List<CommentSelectionResponse> comments;
+}

--- a/src/test/java/mokindang/jubging/project_backend/comment/controller/CommentControllerTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/comment/controller/CommentControllerTest.java
@@ -1,10 +1,14 @@
 package mokindang.jubging.project_backend.comment.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import mokindang.jubging.project_backend.comment.domain.Comment;
+import mokindang.jubging.project_backend.comment.domain.vo.CommentBody;
 import mokindang.jubging.project_backend.comment.service.BoardType;
 import mokindang.jubging.project_backend.comment.service.CommentService;
 import mokindang.jubging.project_backend.comment.service.request.CommentCreationRequest;
 import mokindang.jubging.project_backend.comment.service.response.BoardIdResponse;
+import mokindang.jubging.project_backend.comment.service.response.CommentSelectionResponse;
+import mokindang.jubging.project_backend.comment.service.response.MultiCommentSelectionResponse;
 import mokindang.jubging.project_backend.web.jwt.TokenManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,9 +19,14 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -38,8 +47,8 @@ class CommentControllerTest {
     private TokenManager tokenManager;
 
     @Test
-    @DisplayName("입력받은 boardId 에 해당하는 recruitmentBoard 에 새 댓글을 추가한다.")
-    void addCommentToRecruitmentBoard() throws Exception {
+    @DisplayName("입력받은 BoardType 과 boardId 에 해당하는  게시글에 새 댓글을 추가한다.")
+    void addComment() throws Exception {
         //given
         when(commentService.addComment(anyLong(), any(BoardType.class), anyLong(), any(CommentCreationRequest.class)))
                 .thenReturn(new BoardIdResponse(1L));
@@ -55,5 +64,43 @@ class CommentControllerTest {
         //then
         actual.andExpect(status().isCreated())
                 .andExpect(jsonPath("$.boardId").value(1L));
+    }
+
+    @Test
+    @DisplayName("입력받은 BoardType 과 boardId 에 해당하는 게시글에 새 댓글을 추가한다.")
+    void selectComments() throws Exception {
+        //given
+        CommentSelectionResponse commentSelectionResponse1 = new CommentSelectionResponse(createMockedComment(), 1L);
+        when(commentService.selectComments(anyLong(), any(BoardType.class), anyLong()))
+                .thenReturn(new MultiCommentSelectionResponse(List.of(commentSelectionResponse1)));
+
+
+        //when
+        ResultActions actual = mockMvc.perform(get("/api/{board-type}/{boardId}/comments",
+                "recruitment-board", 1L)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        //then
+        actual.andExpect(status().isOk())
+                .andExpect(jsonPath("$.comments[0].commentId").value(1))
+                .andExpect(jsonPath("$.comments[0].commentBody").value("본문내용"))
+                .andExpect(jsonPath("$.comments[0].mine").value(true))
+                .andExpect(jsonPath("$.comments[0].createdDatetime").value("2023-11-11T11:11:01"))
+                .andExpect(jsonPath("$.comments[0].writerAlias").value("댓글작성자"))
+                .andExpect(jsonPath("$.comments[0].firstFourLettersOfEmail").value("test"))
+                .andExpect(jsonPath("$.comments[0].writerProfileImageUrl").value("test_url"));
+
+    }
+    private Comment createMockedComment() {
+
+        Comment comment = mock(Comment.class);
+        when(comment.getId()).thenReturn(1L);
+        when(comment.getCommentBody()).thenReturn(new CommentBody("본문내용"));
+        when(comment.isSameWriterId(any())).thenReturn(true);
+        when(comment.getCreatedDateTime()).thenReturn(LocalDateTime.of(2023, 11, 11, 11, 11, 1));
+        when(comment.getWriterAlias()).thenReturn("댓글작성자");
+        when(comment.getFirstFourDigitsOfWriterEmail()).thenReturn("test");
+        when(comment.getWriterProfileImageUrl()).thenReturn("test_url");
+        return comment;
     }
 }

--- a/src/test/java/mokindang/jubging/project_backend/comment/domain/CommentTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/comment/domain/CommentTest.java
@@ -1,18 +1,23 @@
-package mokindang.jubging.project_backend.domain.comment;
+package mokindang.jubging.project_backend.comment.domain;
 
-import mokindang.jubging.project_backend.comment.domain.Comment;
 import mokindang.jubging.project_backend.comment.domain.vo.CommentBody;
 import mokindang.jubging.project_backend.member.domain.Member;
 import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
 class CommentTest {
 
     @Test
@@ -70,17 +75,22 @@ class CommentTest {
     @DisplayName("게시글 내용 변경한다. 이때 마지막 수정일을 변경한다.")
     void modify() {
         //given
+        Member writer = mock(Member.class);
+        when(writer.getId()).thenReturn(1L);
+
         SoftAssertions softly = new SoftAssertions();
         RecruitmentBoard recruitmentBoard = createRecruitmentBoard();
         LocalDateTime createdTime = LocalDateTime.of(2023, 4, 8, 16, 48);
-        Member writer = new Member("test@email.com", "test");
+
         String commentBodyValue = "안녕하세요.";
         Comment comment = Comment.createOnRecruitmentBoardWith(recruitmentBoard, commentBodyValue, writer, createdTime);
         String newCommentBody = "하이~~";
         LocalDateTime now = LocalDateTime.of(2023, 5, 9, 11, 11, 11);
 
+        Long writerId = 1L;
+
         //when
-        comment.modify(newCommentBody, now);
+        comment.modify(writerId, newCommentBody, now);
 
         //then
         softly.assertThat(comment.getCommentBody().getBody()).isEqualTo(newCommentBody);
@@ -92,14 +102,16 @@ class CommentTest {
     @DisplayName("게시글이 수정 되었는지에 대한 여부를 반환한다.")
     void wasEdited() {
         //given
+        Member writer = mock(Member.class);
+        when(writer.getId()).thenReturn(1L);
+
         RecruitmentBoard recruitmentBoard = createRecruitmentBoard();
         LocalDateTime createdTime = LocalDateTime.of(2023, 4, 8, 16, 48);
-        Member writer = new Member("test@email.com", "test");
         String commentBodyValue = "안녕하세요.";
         Comment comment = Comment.createOnRecruitmentBoardWith(recruitmentBoard, commentBodyValue, writer, createdTime);
         String newCommentBody = "하이~~";
         LocalDateTime now = LocalDateTime.of(2023, 5, 9, 11, 11, 11);
-        comment.modify(newCommentBody, now);
+        comment.modify(1L,newCommentBody, now);
 
         //when
         boolean actual = comment.wasEdited();

--- a/src/test/java/mokindang/jubging/project_backend/comment/domain/ReplyCommentTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/comment/domain/ReplyCommentTest.java
@@ -1,6 +1,5 @@
-package mokindang.jubging.project_backend.domain.comment;
+package mokindang.jubging.project_backend.comment.domain;
 
-import mokindang.jubging.project_backend.comment.domain.ReplyComment;
 import mokindang.jubging.project_backend.member.domain.Member;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/mokindang/jubging/project_backend/comment/domain/vo/CommentBodyTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/comment/domain/vo/CommentBodyTest.java
@@ -1,6 +1,5 @@
-package mokindang.jubging.project_backend.domain.comment.vo;
+package mokindang.jubging.project_backend.comment.domain.vo;
 
-import mokindang.jubging.project_backend.comment.domain.vo.CommentBody;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/mokindang/jubging/project_backend/comment/service/CommentServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/comment/service/CommentServiceTest.java
@@ -1,7 +1,10 @@
 package mokindang.jubging.project_backend.comment.service;
 
+import mokindang.jubging.project_backend.comment.domain.Comment;
+import mokindang.jubging.project_backend.comment.domain.vo.CommentBody;
 import mokindang.jubging.project_backend.comment.repository.CommentRepository;
 import mokindang.jubging.project_backend.comment.service.request.CommentCreationRequest;
+import mokindang.jubging.project_backend.comment.service.response.MultiCommentSelectionResponse;
 import mokindang.jubging.project_backend.member.domain.Member;
 import mokindang.jubging.project_backend.member.service.MemberService;
 import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
@@ -13,6 +16,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -44,7 +51,7 @@ class CommentServiceTest {
         CommentCreationRequest commentCreateRequest = createCommentCreateRequest();
 
         //when
-        commentService.addComment(1L, BoardType.RECRUITMENT_BOARD,1L, commentCreateRequest);
+        commentService.addComment(1L, BoardType.RECRUITMENT_BOARD, 1L, commentCreateRequest);
 
         //then
         verify(commentRepository, times(1)).save(any());
@@ -54,4 +61,31 @@ class CommentServiceTest {
         return new CommentCreationRequest("댓글 예시 입니다.");
     }
 
+    @Test
+    @DisplayName("입력 받은 게시물의 댓글 리스트를 반환한다.")
+    void selectComments() {
+        //given
+        Comment comment1 = createMockedComment(1L);
+        Comment comment2 = createMockedComment(2L);
+
+        when(commentRepository.findCommentsByRecruitmentBoard(anyLong())).thenReturn(List.of(comment1, comment2));
+
+        //when
+        MultiCommentSelectionResponse multiCommentSelectionResponse = commentService.selectComments(1L, BoardType.RECRUITMENT_BOARD, 1L);
+
+        //then
+        assertThat(multiCommentSelectionResponse.getComments()).hasSize(2);
+    }
+
+    private Comment createMockedComment(final Long commentId) {
+        Comment comment = mock(Comment.class);
+        when(comment.getId()).thenReturn(commentId);
+        when(comment.getCommentBody()).thenReturn(new CommentBody("본문내용"));
+        when(comment.isSameWriterId(any())).thenReturn(true);
+        when(comment.getCreatedDateTime()).thenReturn(LocalDateTime.of(2023, 11, 11, 11, 11, 1));
+        when(comment.getWriterAlias()).thenReturn("댓글작성자");
+        when(comment.getFirstFourDigitsOfWriterEmail()).thenReturn("test");
+        when(comment.getWriterProfileImageUrl()).thenReturn("test_url");
+        return comment;
+    }
 }

--- a/src/test/java/mokindang/jubging/project_backend/comment/service/CommentServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/comment/service/CommentServiceTest.java
@@ -68,7 +68,7 @@ class CommentServiceTest {
         Comment comment1 = createMockedComment(1L);
         Comment comment2 = createMockedComment(2L);
 
-        when(commentRepository.findCommentsByRecruitmentBoard(anyLong())).thenReturn(List.of(comment1, comment2));
+        when(commentRepository.findCommentsByRecruitmentBoardId(anyLong())).thenReturn(List.of(comment1, comment2));
 
         //when
         MultiCommentSelectionResponse multiCommentSelectionResponse = commentService.selectComments(1L, BoardType.RECRUITMENT_BOARD, 1L);

--- a/src/test/java/mokindang/jubging/project_backend/domain/comment/CommentTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/domain/comment/CommentTest.java
@@ -1,6 +1,7 @@
 package mokindang.jubging.project_backend.domain.comment;
 
 import mokindang.jubging.project_backend.comment.domain.Comment;
+import mokindang.jubging.project_backend.comment.domain.vo.CommentBody;
 import mokindang.jubging.project_backend.member.domain.Member;
 import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
 import org.assertj.core.api.SoftAssertions;
@@ -11,7 +12,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
-
+import static org.assertj.core.api.Assertions.assertThat;
 class CommentTest {
 
     @Test
@@ -36,24 +37,33 @@ class CommentTest {
     }
 
     @Test
-    @DisplayName("작성 일시, 작성자, 댓글 본문을 반환한다.")
+    @DisplayName("작성 일시, 작성자, 댓글 본문, 수정 일시을 반환한다.")
     void getter() {
         //given
         SoftAssertions softly = new SoftAssertions();
+        Comment comment = createTestComment();
+
+        //when
+        CommentBody commentBody = comment.getCommentBody();
+        String writerAlias = comment.getWriterAlias();
+        LocalDateTime createdDateTime = comment.getCreatedDateTime();
+        LocalDateTime lastModifiedDateTime = comment.getLastModifiedDateTime();
+
+        //then
+        softly.assertThat(commentBody.getBody()).isEqualTo("안녕하세요.");
+        softly.assertThat(writerAlias).isEqualTo("test");
+        softly.assertThat(createdDateTime).isEqualTo(LocalDateTime.of(2023, 4, 8, 16, 48));
+        softly.assertThat(lastModifiedDateTime).isEqualTo(LocalDateTime.of(2023, 4, 8, 16, 48));
+        softly.assertAll();
+    }
+
+    private Comment createTestComment() {
         RecruitmentBoard recruitmentBoard = createRecruitmentBoard();
         LocalDateTime now = LocalDateTime.of(2023, 4, 8, 16, 48);
         Member writer = new Member("test@email.com", "test");
+        writer.updateProfileImage("test_url", "image");
         String commentBodyValue = "안녕하세요.";
-
-        //when
-        Comment comment = Comment.createOnRecruitmentBoardWith(recruitmentBoard, commentBodyValue, writer, now);
-
-        //then
-        softly.assertThat(comment.getCommentBody().getBody()).isEqualTo("안녕하세요.");
-        softly.assertThat(comment.getWriter()).isEqualTo(writer);
-        softly.assertThat(comment.getCreatedDateTime()).isEqualTo(now);
-        softly.assertThat(comment.getLastModifiedDateTime()).isEqualTo(now);
-        softly.assertAll();
+        return Comment.createOnRecruitmentBoardWith(recruitmentBoard, commentBodyValue, writer, now);
     }
 
     @Test
@@ -76,5 +86,64 @@ class CommentTest {
         softly.assertThat(comment.getCommentBody().getBody()).isEqualTo(newCommentBody);
         softly.assertThat(comment.getLastModifiedDateTime()).isEqualTo(now);
         softly.assertAll();
+    }
+
+    @Test
+    @DisplayName("게시글이 수정 되었는지에 대한 여부를 반환한다.")
+    void wasEdited() {
+        //given
+        RecruitmentBoard recruitmentBoard = createRecruitmentBoard();
+        LocalDateTime createdTime = LocalDateTime.of(2023, 4, 8, 16, 48);
+        Member writer = new Member("test@email.com", "test");
+        String commentBodyValue = "안녕하세요.";
+        Comment comment = Comment.createOnRecruitmentBoardWith(recruitmentBoard, commentBodyValue, writer, createdTime);
+        String newCommentBody = "하이~~";
+        LocalDateTime now = LocalDateTime.of(2023, 5, 9, 11, 11, 11);
+        comment.modify(newCommentBody, now);
+
+        //when
+        boolean actual = comment.wasEdited();
+
+        //then
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    @DisplayName("댓글 작성자의 닉네임을 반환한다.")
+    void getWriterAlias() {
+        //given
+        Comment comment = createTestComment();
+
+        //when
+        String actual = comment.getWriterAlias();
+
+        //then
+        assertThat(actual).isEqualTo("test");
+    }
+
+    @Test
+    @DisplayName("작성자의 이메일 앞 4자리를 반환한다.")
+    void getFirstFourDigitsOfWriterEmail() {
+        //given
+        Comment comment = createTestComment();
+
+        //when
+        String actual = comment.getFirstFourDigitsOfWriterEmail();
+
+        //then
+        assertThat(actual).isEqualTo("test");
+    }
+
+    @Test
+    @DisplayName("댓글 작성자의 프로필 url 을 반환한다.")
+    void getWriterProfileImageUrl() {
+        //given
+        Comment comment = createTestComment();
+
+        //when
+        String actual = comment.getWriterProfileImageUrl();
+
+        //then
+        assertThat(actual).isEqualTo("test_url");
     }
 }


### PR DESCRIPTION
# Feature/#311/댓글 조회 api 구현

### 이슈 번호 : #311 

## 변경 사항
-    댓글 리스트 조회 api 구현에 따른 변경
    -  CommentRepository 의 각 게시글 종류에 해당하는 boardId 값에 따라 댓글 리스트를 조회하도록하는 메서드 추가
    - CommentService 의 댓글 조회 메서드 구현
    - Comment 내부에서 댓글의 작성자 정보를 반환하도록 하는 메서드 구현
    - CommentController 에 댓글 조회 api 구현
    - CommentControllerSwagger 수정

## 그 외
- 

## 질문 사항
- 
