### PR TITLE
refactor : #346 회원 생성 시 기존 프로필 이미지 url 주입

### DIFF
--- a/src/main/java/mokindang/jubging/project_backend/image/service/ImageService.java
+++ b/src/main/java/mokindang/jubging/project_backend/image/service/ImageService.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 
 import static mokindang.jubging.project_backend.file.FileService.CERTIFICATION_BOARD_IMAGE;
 import static mokindang.jubging.project_backend.file.FileService.PROFILE_IMAGE;
+import static mokindang.jubging.project_backend.member.domain.vo.ProfileImage.DEFAULT_PROFILE_IMAGE_URL;
 
 @Slf4j
 @Service
@@ -27,7 +28,6 @@ import static mokindang.jubging.project_backend.file.FileService.PROFILE_IMAGE;
 @RequiredArgsConstructor
 public class ImageService {
 
-    private final String defaultImageUrl = "https://dognejupging-xyz-image-bucket.s3.ap-northeast-2.amazonaws.com/profile_image/profileimage2.png";
     private final ImageRepository imageRepository;
     private final FileService fileService;
     private final MemberService memberService;
@@ -105,6 +105,6 @@ public class ImageService {
     }
 
     public ImageUrlResponse getDefaultImageUrl() {
-        return new ImageUrlResponse(defaultImageUrl);
+        return new ImageUrlResponse(DEFAULT_PROFILE_IMAGE_URL);
     }
 }

--- a/src/main/java/mokindang/jubging/project_backend/member/domain/vo/ProfileImage.java
+++ b/src/main/java/mokindang/jubging/project_backend/member/domain/vo/ProfileImage.java
@@ -12,7 +12,7 @@ import javax.persistence.Embeddable;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProfileImage {
 
-    public static final String DEFAULT_PROFILE_IMAGE_URL = "DEFAULT_PROFILE_IMAGE_URL";
+    public static final String DEFAULT_PROFILE_IMAGE_URL = "https://dognejupging-xyz-image-bucket.s3.ap-northeast-2.amazonaws.com/profile_image/profileimage2.png";
 
     @Column(name = "profile_image_url", nullable = false)
     private String profileImageUrl;

--- a/src/main/java/mokindang/jubging/project_backend/member/service/response/MyPageResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/member/service/response/MyPageResponse.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MyPageResponse {
 
-    @Schema(description = "마이페이지 프로필 URL", example = "DEFAULT_PROFILE_IMAGE_URL")
+    @Schema(description = "마이페이지 프로필 URL", example = "기본 프로필 이미지 url")
     private final String profileImageUrl;
 
     @Schema(description = "마이페이지 닉네임", example = "민호")

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,5 +1,5 @@
 INSERT INTO member (EMAIL, ALIAS, REGION, PROFILE_IMAGE_URL)
-VALUES ('test@email.com', '테스트유저', '동작구', 'DEFAULT_PROFILE_IMAGE_URL');
+VALUES ('test@email.com', '테스트유저', '동작구', 'https://dognejupging-xyz-image-bucket.s3.ap-northeast-2.amazonaws.com/profile_image/profileimage2.png');
 INSERT INTO recruitment_board (MEMBER_ID, CREATING_DATE_TIME, STARTING_DATE, ACTIVITY_CATEGORY, TITLE, CONTENT_BODY, REGION, ON_RECRUITMENT)
 VALUES (1,'2023-3-9-12-0', '2023-3-15', 'RUNNING', '제목', '본문내용', '동작구', false);
 INSERT INTO comment (body, created_date_time, last_modified_date_time, certification_board_id, recruitment_board_id, member_id)

--- a/src/test/java/mokindang/jubging/project_backend/service/member/MemberServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/service/member/MemberServiceTest.java
@@ -1,11 +1,11 @@
 package mokindang.jubging.project_backend.service.member;
 
+import mokindang.jubging.project_backend.file.FileService;
 import mokindang.jubging.project_backend.member.domain.Member;
 import mokindang.jubging.project_backend.member.domain.vo.Region;
 import mokindang.jubging.project_backend.member.repository.MemberRepository;
 import mokindang.jubging.project_backend.member.service.KaKaoLocalApi;
 import mokindang.jubging.project_backend.member.service.MemberService;
-import mokindang.jubging.project_backend.file.FileService;
 import mokindang.jubging.project_backend.member.service.request.RegionUpdateRequest;
 import mokindang.jubging.project_backend.member.service.response.MyPageResponse;
 import org.junit.jupiter.api.DisplayName;
@@ -18,6 +18,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.Optional;
 
+import static mokindang.jubging.project_backend.member.domain.vo.ProfileImage.DEFAULT_PROFILE_IMAGE_URL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -107,6 +108,6 @@ class MemberServiceTest {
         //then
         assertThat(myInformation.getAlias()).isEqualTo("test");
         assertThat(myInformation.getRegion()).isEqualTo("부천시");
-        assertThat(myInformation.getProfileImageUrl()).isEqualTo("DEFAULT_PROFILE_IMAGE_URL");
+        assertThat(myInformation.getProfileImageUrl()).isEqualTo(DEFAULT_PROFILE_IMAGE_URL);
     }
 }


### PR DESCRIPTION
# refactor : #346 회원 생성 시 기존 프로필 이미지 url 주입

### 이슈 번호 : #346 

## 변경 사항
-    기존 회원 생성시 DEFAULT_IMAGE_PROFILE_URL 주입 대신 실제 url을 주입하도록 변경

## 그 외
- 

## 질문 사항
- 
