### PR TITLE
Refactor/#348/구인 게시글 수정 시 좌표와 상세 주소를 입력 받도록 변경

### DIFF
--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/domain/RecruitmentBoard.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/domain/RecruitmentBoard.java
@@ -7,7 +7,10 @@ import mokindang.jubging.project_backend.comment.domain.Comment;
 import mokindang.jubging.project_backend.exception.custom.ForbiddenException;
 import mokindang.jubging.project_backend.member.domain.Member;
 import mokindang.jubging.project_backend.member.domain.vo.Region;
-import mokindang.jubging.project_backend.recruitment_board.domain.vo.*;
+import mokindang.jubging.project_backend.recruitment_board.domain.vo.ContentBody;
+import mokindang.jubging.project_backend.recruitment_board.domain.vo.Place;
+import mokindang.jubging.project_backend.recruitment_board.domain.vo.StartingDate;
+import mokindang.jubging.project_backend.recruitment_board.domain.vo.Title;
 
 import javax.persistence.*;
 import java.time.LocalDate;
@@ -92,13 +95,14 @@ public class RecruitmentBoard {
     }
 
     public void modify(final Long memberId, final LocalDate startingDate, final String activityCategoryValue,
-                       final String titleValue, final String contentValue) {
+                       final String titleValue, final String contentValue, final Place place) {
         validatePermission(memberId);
         LocalDate today = LocalDate.now();
         this.startingDate = new StartingDate(today, startingDate);
         this.activityCategory = ActivityCategory.from(activityCategoryValue);
         this.title = new Title(titleValue);
         this.contentBody = new ContentBody(contentValue);
+        this.meetingPlace = place;
     }
 
     public boolean isSameWriterId(final Long memberId) {

--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/RecruitmentBoardService.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/RecruitmentBoardService.java
@@ -9,7 +9,8 @@ import mokindang.jubging.project_backend.recruitment_board.domain.vo.Coordinate;
 import mokindang.jubging.project_backend.recruitment_board.domain.vo.Place;
 import mokindang.jubging.project_backend.recruitment_board.repository.RecruitmentBoardRepository;
 import mokindang.jubging.project_backend.recruitment_board.service.request.BoardModificationRequest;
-import mokindang.jubging.project_backend.recruitment_board.service.request.MeetingPlaceRequest;
+import mokindang.jubging.project_backend.recruitment_board.service.request.MeetingPlaceCreationRequest;
+import mokindang.jubging.project_backend.recruitment_board.service.request.MeetingPlaceModificationRequest;
 import mokindang.jubging.project_backend.recruitment_board.service.request.RecruitmentBoardCreationRequest;
 import mokindang.jubging.project_backend.recruitment_board.service.response.MultiBoardSelectResponse;
 import mokindang.jubging.project_backend.recruitment_board.service.response.RecruitmentBoardIdResponse;
@@ -36,17 +37,17 @@ public class RecruitmentBoardService {
     public RecruitmentBoardIdResponse write(final Long memberId, final RecruitmentBoardCreationRequest recruitmentBoardCreationRequest) {
         Member member = memberService.findByMemberId(memberId);
         LocalDateTime now = LocalDateTime.now();
-        Place meetingPlace = generatePlace(recruitmentBoardCreationRequest.getMeetingPlaceRequest());
+        Place meetingPlace = generateModificationPlace(recruitmentBoardCreationRequest.getMeetingPlaceCreationRequest());
         RecruitmentBoard recruitmentBoard = new RecruitmentBoard(now, member, recruitmentBoardCreationRequest.getStartingDate(),
                 recruitmentBoardCreationRequest.getActivityCategory(), meetingPlace, recruitmentBoardCreationRequest.getTitle(), recruitmentBoardCreationRequest.getContentBody());
         RecruitmentBoard savedRecruitmentBoard = recruitmentBoardRepository.save(recruitmentBoard);
         return new RecruitmentBoardIdResponse(savedRecruitmentBoard.getId());
     }
 
-    private static Place generatePlace(final MeetingPlaceRequest meetingPlaceRequest) {
-        Coordinate meetingSpot = new Coordinate(meetingPlaceRequest.getLongitude(),
-                meetingPlaceRequest.getLatitude());
-        String meetingAddress = meetingPlaceRequest.getMeetingAddress();
+    private Place generateModificationPlace(final MeetingPlaceCreationRequest meetingPlaceCreationRequest) {
+        Coordinate meetingSpot = new Coordinate(meetingPlaceCreationRequest.getLongitude(),
+                meetingPlaceCreationRequest.getLatitude());
+        String meetingAddress = meetingPlaceCreationRequest.getMeetingAddress();
         return new Place(meetingSpot, meetingAddress);
     }
 
@@ -79,10 +80,17 @@ public class RecruitmentBoardService {
     @Transactional
     public RecruitmentBoardIdResponse modify(final Long memberId, final Long boardId, final BoardModificationRequest boardModificationRequest) {
         RecruitmentBoard recruitmentBoard = findById(boardId);
-        Place place = generatePlace(boardModificationRequest.getMeetingPlaceRequest());
+        Place place = generateModificationPlace(boardModificationRequest.getMeetingPlaceModificationRequest());
         recruitmentBoard.modify(memberId, boardModificationRequest.getStartingDate(), boardModificationRequest.getActivityCategory(),
                 boardModificationRequest.getTitle(), boardModificationRequest.getContentBody(), place);
         return new RecruitmentBoardIdResponse(recruitmentBoard.getId());
+    }
+
+    private Place generateModificationPlace(final MeetingPlaceModificationRequest meetingPlaceModificationRequest) {
+        Coordinate meetingSpot = new Coordinate(meetingPlaceModificationRequest.getLongitude(),
+                meetingPlaceModificationRequest.getLatitude());
+        String meetingAddress = meetingPlaceModificationRequest.getMeetingAddress();
+        return new Place(meetingSpot, meetingAddress);
     }
 
     @Transactional

--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/RecruitmentBoardService.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/RecruitmentBoardService.java
@@ -9,6 +9,7 @@ import mokindang.jubging.project_backend.recruitment_board.domain.vo.Coordinate;
 import mokindang.jubging.project_backend.recruitment_board.domain.vo.Place;
 import mokindang.jubging.project_backend.recruitment_board.repository.RecruitmentBoardRepository;
 import mokindang.jubging.project_backend.recruitment_board.service.request.BoardModificationRequest;
+import mokindang.jubging.project_backend.recruitment_board.service.request.MeetingPlaceRequest;
 import mokindang.jubging.project_backend.recruitment_board.service.request.RecruitmentBoardCreationRequest;
 import mokindang.jubging.project_backend.recruitment_board.service.response.MultiBoardSelectResponse;
 import mokindang.jubging.project_backend.recruitment_board.service.response.RecruitmentBoardIdResponse;
@@ -35,13 +36,18 @@ public class RecruitmentBoardService {
     public RecruitmentBoardIdResponse write(final Long memberId, final RecruitmentBoardCreationRequest recruitmentBoardCreationRequest) {
         Member member = memberService.findByMemberId(memberId);
         LocalDateTime now = LocalDateTime.now();
-        Coordinate meetingSpot = new Coordinate(recruitmentBoardCreationRequest.getLongitude(), recruitmentBoardCreationRequest.getLatitude());
-        String meetingAddress = recruitmentBoardCreationRequest.getMeetingAddress();
-        Place meetingPlace = new Place(meetingSpot, meetingAddress);
+        Place meetingPlace = generatePlace(recruitmentBoardCreationRequest.getMeetingPlaceRequest());
         RecruitmentBoard recruitmentBoard = new RecruitmentBoard(now, member, recruitmentBoardCreationRequest.getStartingDate(),
                 recruitmentBoardCreationRequest.getActivityCategory(), meetingPlace, recruitmentBoardCreationRequest.getTitle(), recruitmentBoardCreationRequest.getContentBody());
         RecruitmentBoard savedRecruitmentBoard = recruitmentBoardRepository.save(recruitmentBoard);
         return new RecruitmentBoardIdResponse(savedRecruitmentBoard.getId());
+    }
+
+    private static Place generatePlace(final MeetingPlaceRequest meetingPlaceRequest) {
+        Coordinate meetingSpot = new Coordinate(meetingPlaceRequest.getLongitude(),
+                meetingPlaceRequest.getLatitude());
+        String meetingAddress = meetingPlaceRequest.getMeetingAddress();
+        return new Place(meetingSpot, meetingAddress);
     }
 
     public RecruitmentBoardSelectionResponse select(final Long memberId, final Long boardId) {
@@ -73,8 +79,9 @@ public class RecruitmentBoardService {
     @Transactional
     public RecruitmentBoardIdResponse modify(final Long memberId, final Long boardId, final BoardModificationRequest boardModificationRequest) {
         RecruitmentBoard recruitmentBoard = findById(boardId);
+        Place place = generatePlace(boardModificationRequest.getMeetingPlaceRequest());
         recruitmentBoard.modify(memberId, boardModificationRequest.getStartingDate(), boardModificationRequest.getActivityCategory(),
-                boardModificationRequest.getTitle(), boardModificationRequest.getContentBody());
+                boardModificationRequest.getTitle(), boardModificationRequest.getContentBody(), place);
         return new RecruitmentBoardIdResponse(recruitmentBoard.getId());
     }
 

--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/request/BoardModificationRequest.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/request/BoardModificationRequest.java
@@ -35,5 +35,5 @@ public class BoardModificationRequest {
 
     @NotNull
     @Schema(description = "변경될 장소 경도 좌표", example = "12.12312412")
-    private final MeetingPlaceRequest meetingPlaceRequest;
+    private final MeetingPlaceModificationRequest meetingPlaceModificationRequest;
 }

--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/request/BoardModificationRequest.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/request/BoardModificationRequest.java
@@ -32,4 +32,8 @@ public class BoardModificationRequest {
     @Schema(description = "변경될 활동 시작일", example = "2023-11-23", pattern = "yyyy-MM-dd")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private final LocalDate startingDate;
+
+    @NotNull
+    @Schema(description = "변경될 장소 경도 좌표", example = "12.12312412")
+    private final MeetingPlaceRequest meetingPlaceRequest;
 }

--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/request/MeetingPlaceCreationRequest.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/request/MeetingPlaceCreationRequest.java
@@ -1,0 +1,23 @@
+package mokindang.jubging.project_backend.recruitment_board.service.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@RequiredArgsConstructor
+public class MeetingPlaceCreationRequest {
+    @NotNull
+    @Schema(description = "활동 장소 경도 좌표", example = "12.12312412")
+    private final Double longitude;
+
+    @NotNull
+    @Schema(description = "활동 장소 위도 좌표", example = "34.12312312")
+    private final Double latitude;
+
+    @NotNull
+    @Schema(description = "활동 장소 상세 주소", example = "서울시 동작구 상도동 1-1")
+    private final String meetingAddress;
+}

--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/request/MeetingPlaceModificationRequest.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/request/MeetingPlaceModificationRequest.java
@@ -9,7 +9,7 @@ import javax.validation.constraints.NotNull;
 @Schema
 @Getter
 @RequiredArgsConstructor
-public class MeetingPlaceRequest {
+public class MeetingPlaceModificationRequest {
 
     @NotNull
     @Schema(description = "활동 장소 경도 좌표", example = "12.12312412")

--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/request/MeetingPlaceRequest.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/request/MeetingPlaceRequest.java
@@ -1,0 +1,25 @@
+package mokindang.jubging.project_backend.recruitment_board.service.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Schema
+@Getter
+@RequiredArgsConstructor
+public class MeetingPlaceRequest {
+
+    @NotNull
+    @Schema(description = "활동 장소 경도 좌표", example = "12.12312412")
+    private final Double longitude;
+
+    @NotNull
+    @Schema(description = "활동 장소 위도 좌표", example = "34.12312312")
+    private final Double latitude;
+
+    @NotNull
+    @Schema(description = "활동 장소 상세 주소", example = "서울시 동작구 상도동 1-1")
+    private final String meetingAddress;
+}

--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/request/RecruitmentBoardCreationRequest.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/request/RecruitmentBoardCreationRequest.java
@@ -36,5 +36,5 @@ public class RecruitmentBoardCreationRequest {
 
     @NotNull
     @Schema(description = "활동 장소")
-    private final MeetingPlaceRequest meetingPlaceRequest;
+    private final MeetingPlaceCreationRequest meetingPlaceCreationRequest;
 }

--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/request/RecruitmentBoardCreationRequest.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/request/RecruitmentBoardCreationRequest.java
@@ -35,14 +35,6 @@ public class RecruitmentBoardCreationRequest {
     private final LocalDate startingDate;
 
     @NotNull
-    @Schema(description = "활동 장소 경도 좌표", example = "12.12312412")
-    private final Double longitude;
-
-    @NotNull
-    @Schema(description = "활동 장소 위도 좌표", example = "34.12312312")
-    private final Double latitude;
-
-    @NotNull
-    @Schema(description = "활동 장소 상세 주소", example = "서울시 동작구 상도동 1-1")
-    private final String meetingAddress;
+    @Schema(description = "활동 장소")
+    private final MeetingPlaceRequest meetingPlaceRequest;
 }

--- a/src/test/java/mokindang/jubging/project_backend/controller/board/RecruitmentBoardControllerTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/controller/board/RecruitmentBoardControllerTest.java
@@ -9,7 +9,8 @@ import mokindang.jubging.project_backend.recruitment_board.domain.vo.Coordinate;
 import mokindang.jubging.project_backend.recruitment_board.domain.vo.Place;
 import mokindang.jubging.project_backend.recruitment_board.service.RecruitmentBoardService;
 import mokindang.jubging.project_backend.recruitment_board.service.request.BoardModificationRequest;
-import mokindang.jubging.project_backend.recruitment_board.service.request.MeetingPlaceRequest;
+import mokindang.jubging.project_backend.recruitment_board.service.request.MeetingPlaceCreationRequest;
+import mokindang.jubging.project_backend.recruitment_board.service.request.MeetingPlaceModificationRequest;
 import mokindang.jubging.project_backend.recruitment_board.service.request.RecruitmentBoardCreationRequest;
 import mokindang.jubging.project_backend.recruitment_board.service.response.MultiBoardSelectResponse;
 import mokindang.jubging.project_backend.recruitment_board.service.response.RecruitmentBoardIdResponse;
@@ -73,13 +74,13 @@ class RecruitmentBoardControllerTest {
     }
 
     private RecruitmentBoardCreationRequest createTestRecruitmentBoardCreationRequest() {
-        MeetingPlaceRequest meetingPlaceRequest = createTestMeetingPlaceRequest();
+        MeetingPlaceCreationRequest meetingPlaceModificationRequest = createTestMeetingPlaceCreationRequest();
         return new RecruitmentBoardCreationRequest("제목", "본문", "달리기",
-                LocalDate.of(2023, 11, 11), meetingPlaceRequest);
+                LocalDate.of(2023, 11, 11), meetingPlaceModificationRequest);
     }
 
-    private  MeetingPlaceRequest createTestMeetingPlaceRequest() {
-        return new MeetingPlaceRequest(1.1, 1.2, "서울시 동작구 상도동 1-1");
+    private MeetingPlaceCreationRequest createTestMeetingPlaceCreationRequest() {
+        return new MeetingPlaceCreationRequest(1.1, 1.2, "서울시 동작구 상도동 1-1");
     }
 
     @Test
@@ -305,13 +306,13 @@ class RecruitmentBoardControllerTest {
     }
 
     private  BoardModificationRequest createTestModificationRequest() {
-        MeetingPlaceRequest meetingPlaceRequest = createTestMeetingPlaceRequest();
+        MeetingPlaceModificationRequest meetingPlaceModificationRequest = new MeetingPlaceModificationRequest(1.1, 1.2, "서울시 동작구 상도동 1-1");
 
         return new BoardModificationRequest("새로운 제목", "새로운 본문",
-                "산책", LocalDate.of(2023, 1, 1), meetingPlaceRequest);
+                "산책", LocalDate.of(2023, 1, 1), meetingPlaceModificationRequest);
     }
 
-    @Test
+        @Test
     @DisplayName("게시글 수정 요청 시, 존재하지 않는 게시글에 대한 수정을 요청할 시 HTTP 400 과 예외를 담은 ErrorResponse 를 반환한다.")
     void modifyFailedByNonexistentBoard() throws Exception {
         //given

--- a/src/test/java/mokindang/jubging/project_backend/controller/board/RecruitmentBoardControllerTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/controller/board/RecruitmentBoardControllerTest.java
@@ -9,6 +9,7 @@ import mokindang.jubging.project_backend.recruitment_board.domain.vo.Coordinate;
 import mokindang.jubging.project_backend.recruitment_board.domain.vo.Place;
 import mokindang.jubging.project_backend.recruitment_board.service.RecruitmentBoardService;
 import mokindang.jubging.project_backend.recruitment_board.service.request.BoardModificationRequest;
+import mokindang.jubging.project_backend.recruitment_board.service.request.MeetingPlaceRequest;
 import mokindang.jubging.project_backend.recruitment_board.service.request.RecruitmentBoardCreationRequest;
 import mokindang.jubging.project_backend.recruitment_board.service.response.MultiBoardSelectResponse;
 import mokindang.jubging.project_backend.recruitment_board.service.response.RecruitmentBoardIdResponse;
@@ -59,8 +60,7 @@ class RecruitmentBoardControllerTest {
         //given
         when(boardService.write(anyLong(), any(RecruitmentBoardCreationRequest.class))).thenReturn(new RecruitmentBoardIdResponse(1L));
 
-        RecruitmentBoardCreationRequest boardCreationRequest = new RecruitmentBoardCreationRequest("제목", "본문", "달리기",
-                LocalDate.of(2023, 11, 11), 1.1, 1.2, "서울시 동작구 상도동 1-1");
+        RecruitmentBoardCreationRequest boardCreationRequest = createTestRecruitmentBoardCreationRequest();
 
         //when
         ResultActions actual = mockMvc.perform(post("/api/boards/recruitment")
@@ -72,6 +72,16 @@ class RecruitmentBoardControllerTest {
                 .andExpect(jsonPath("$.boardId").value(1L));
     }
 
+    private RecruitmentBoardCreationRequest createTestRecruitmentBoardCreationRequest() {
+        MeetingPlaceRequest meetingPlaceRequest = createTestMeetingPlaceRequest();
+        return new RecruitmentBoardCreationRequest("제목", "본문", "달리기",
+                LocalDate.of(2023, 11, 11), meetingPlaceRequest);
+    }
+
+    private  MeetingPlaceRequest createTestMeetingPlaceRequest() {
+        return new MeetingPlaceRequest(1.1, 1.2, "서울시 동작구 상도동 1-1");
+    }
+
     @Test
     @DisplayName("새 게시글 작성 시, 유저가 존재하지 않으면 HTTP 400 을 반환한다.")
     void writeFailedByNonexistentMember() throws Exception {
@@ -79,8 +89,7 @@ class RecruitmentBoardControllerTest {
         doThrow(new IllegalArgumentException("해당하는 유저가 존재하지 않습니다.")).when(boardService)
                 .write(anyLong(), any(RecruitmentBoardCreationRequest.class));
 
-        RecruitmentBoardCreationRequest boardCreationRequest = new RecruitmentBoardCreationRequest("제목", "본문", "달리기",
-                LocalDate.of(2023, 11, 11), 1.1, 1.2, "서울시 동작구 상도동 1-1");
+        RecruitmentBoardCreationRequest boardCreationRequest = createTestRecruitmentBoardCreationRequest();
 
         //when
         ResultActions actual = mockMvc.perform(post("/api/boards/recruitment")
@@ -99,8 +108,7 @@ class RecruitmentBoardControllerTest {
         doThrow(new IllegalArgumentException("글 제목은 1글자 이상 140자 이하야합니다.")).when(boardService)
                 .write(anyLong(), any(RecruitmentBoardCreationRequest.class));
 
-        RecruitmentBoardCreationRequest incorrectTitleRequest = new RecruitmentBoardCreationRequest("잘못된 제목", "본문", "달리기",
-                LocalDate.of(2023, 11, 11), 1.1, 1.2, "서울시 동작구 상도동 1-1");
+        RecruitmentBoardCreationRequest incorrectTitleRequest = createTestRecruitmentBoardCreationRequest();
 
         //when
         ResultActions actual = mockMvc.perform(post("/api/boards/recruitment")
@@ -119,8 +127,7 @@ class RecruitmentBoardControllerTest {
         doThrow(new IllegalArgumentException("글 내용은 최소 1자 이상, 최대 4000자 입니다.")).when(boardService)
                 .write(anyLong(), any(RecruitmentBoardCreationRequest.class));
 
-        RecruitmentBoardCreationRequest incorrectContentRequest = new RecruitmentBoardCreationRequest("제목", "잘못된 본문", "달리기",
-                LocalDate.of(2023, 11, 11), 1.1, 1.2, "서울시 동작구 상도동 1-1");
+        RecruitmentBoardCreationRequest incorrectContentRequest = createTestRecruitmentBoardCreationRequest();
 
         //when
         ResultActions actual = mockMvc.perform(post("/api/boards/recruitment")
@@ -139,8 +146,7 @@ class RecruitmentBoardControllerTest {
         doThrow(new IllegalArgumentException("이미 지난 날짜는 활동 시작일로 할 수 없습니다.")).when(boardService)
                 .write(anyLong(), any(RecruitmentBoardCreationRequest.class));
 
-        RecruitmentBoardCreationRequest incorrectContentRequest = new RecruitmentBoardCreationRequest("제목", "잘못된 본문", "달리기",
-                LocalDate.of(2023, 11, 11), 1.1, 1.2, "서울시 동작구 상도동 1-1");
+        RecruitmentBoardCreationRequest incorrectContentRequest = createTestRecruitmentBoardCreationRequest();
 
         //when
         ResultActions actual = mockMvc.perform(post("/api/boards/recruitment")
@@ -286,8 +292,7 @@ class RecruitmentBoardControllerTest {
         RecruitmentBoardIdResponse boardIdResponse = new RecruitmentBoardIdResponse(1L);
         when(boardService.modify(anyLong(), anyLong(), any(BoardModificationRequest.class))).thenReturn(boardIdResponse);
 
-        BoardModificationRequest boardModificationRequest = new BoardModificationRequest("새로운 제목", "새로운 본문",
-                "산책", LocalDate.of(2023, 1, 1));
+        BoardModificationRequest boardModificationRequest = createTestModificationRequest();
 
         //when
         ResultActions actual = mockMvc.perform(patch("/api/boards/recruitment/{boardId}", 1L)
@@ -299,6 +304,13 @@ class RecruitmentBoardControllerTest {
                 .andExpect(jsonPath("$.boardId").value(1));
     }
 
+    private  BoardModificationRequest createTestModificationRequest() {
+        MeetingPlaceRequest meetingPlaceRequest = createTestMeetingPlaceRequest();
+
+        return new BoardModificationRequest("새로운 제목", "새로운 본문",
+                "산책", LocalDate.of(2023, 1, 1), meetingPlaceRequest);
+    }
+
     @Test
     @DisplayName("게시글 수정 요청 시, 존재하지 않는 게시글에 대한 수정을 요청할 시 HTTP 400 과 예외를 담은 ErrorResponse 를 반환한다.")
     void modifyFailedByNonexistentBoard() throws Exception {
@@ -306,8 +318,7 @@ class RecruitmentBoardControllerTest {
         doThrow(new IllegalArgumentException("존재하지 않는 게시물입니다.")).when(boardService)
                 .modify(anyLong(), anyLong(), any(BoardModificationRequest.class));
 
-        BoardModificationRequest boardModificationRequest = new BoardModificationRequest("새로운 제목", "새로운 본문",
-                "산책", LocalDate.of(2023, 1, 1));
+        BoardModificationRequest boardModificationRequest = createTestModificationRequest();
 
         //when
         ResultActions actual = mockMvc.perform(patch("/api/boards/recruitment/{boardId}", 1L)
@@ -326,8 +337,7 @@ class RecruitmentBoardControllerTest {
         doThrow(new ForbiddenException("글 작성자만 게시글을 수정할 수 있습니다.")).when(boardService)
                 .modify(anyLong(), anyLong(), any(BoardModificationRequest.class));
 
-        BoardModificationRequest boardModificationRequest = new BoardModificationRequest("새로운 제목", "새로운 본문",
-                "산책", LocalDate.of(2023, 1, 1));
+        BoardModificationRequest boardModificationRequest = createTestModificationRequest();
 
         //when
         ResultActions actual = mockMvc.perform(patch("/api/boards/recruitment/{boardId}", 1L)

--- a/src/test/java/mokindang/jubging/project_backend/domain/board/recruitment/RecruitmentBoardTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/domain/board/recruitment/RecruitmentBoardTest.java
@@ -243,15 +243,17 @@ class RecruitmentBoardTest {
         String newTitleValue = "새로운 제목입니다.";
         String newContentValue = "새로운 본문 내용입니다.";
         LocalDate newStartingDate = LocalDate.parse("2023-11-13");
+        Place place = new Place(new Coordinate(1.1, 1.2), "서울시 동작구 상도동 1-1");
 
         //when
-        recruitmentBoard.modify(writerId, newStartingDate, newActivityCategory, newTitleValue, newContentValue);
+        recruitmentBoard.modify(writerId, newStartingDate, newActivityCategory, newTitleValue, newContentValue, place);
 
         //then
         softly.assertThat(recruitmentBoard.getStartingDate().getValue()).isEqualTo("2023-11-13");
         softly.assertThat(recruitmentBoard.getActivityCategory().getValue()).isEqualTo(newActivityCategory);
         softly.assertThat(recruitmentBoard.getTitle().getValue()).isEqualTo(newTitleValue);
         softly.assertThat(recruitmentBoard.getContentBody().getValue()).isEqualTo(newContentValue);
+        softly.assertThat(recruitmentBoard.getMeetingPlace()).isEqualTo(place);
         softly.assertAll();
     }
 
@@ -265,9 +267,10 @@ class RecruitmentBoardTest {
         String newTitleValue = "새로운 제목입니다.";
         String newContentValue = "새로운 본문 내용입니다.";
         LocalDate newStartingDate = LocalDate.parse("2023-11-13");
+        Place place = new Place(new Coordinate(1.1, 1.2), "서울시 동작구 상도동 1-1");
 
         //when, then
-        assertThatThrownBy(() -> recruitmentBoard.modify(noneWriterId, newStartingDate, newActivityCategory, newTitleValue, newContentValue))
+        assertThatThrownBy(() -> recruitmentBoard.modify(noneWriterId, newStartingDate, newActivityCategory, newTitleValue, newContentValue,place))
                 .isInstanceOf(ForbiddenException.class)
                 .hasMessage("작성자 권한이 없습니다.");
     }

--- a/src/test/java/mokindang/jubging/project_backend/service/board/RecruitmentBoardServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/service/board/RecruitmentBoardServiceTest.java
@@ -9,6 +9,7 @@ import mokindang.jubging.project_backend.recruitment_board.domain.vo.*;
 import mokindang.jubging.project_backend.recruitment_board.repository.RecruitmentBoardRepository;
 import mokindang.jubging.project_backend.recruitment_board.service.RecruitmentBoardService;
 import mokindang.jubging.project_backend.recruitment_board.service.request.BoardModificationRequest;
+import mokindang.jubging.project_backend.recruitment_board.service.request.MeetingPlaceRequest;
 import mokindang.jubging.project_backend.recruitment_board.service.request.RecruitmentBoardCreationRequest;
 import mokindang.jubging.project_backend.recruitment_board.service.response.MultiBoardSelectResponse;
 import mokindang.jubging.project_backend.recruitment_board.service.response.RecruitmentBoardIdResponse;
@@ -61,8 +62,7 @@ class RecruitmentBoardServiceTest {
         when(savedBoard.getId()).thenReturn(1L);
         when(boardRepository.save(any(RecruitmentBoard.class))).thenReturn(savedBoard);
 
-        RecruitmentBoardCreationRequest recruitmentBoardCreationRequest = new RecruitmentBoardCreationRequest("제목", "본문내용", "달리기",
-                LocalDate.of(2025, 2, 12), 1.1, 1.2, "서울시 동작구 상도동 1-1");
+        RecruitmentBoardCreationRequest recruitmentBoardCreationRequest = createTestRecruitmentBoardCreationRequest();
 
         //when
         RecruitmentBoardIdResponse savedBoardId = boardService.write(1L, recruitmentBoardCreationRequest);
@@ -72,14 +72,23 @@ class RecruitmentBoardServiceTest {
         verify(boardRepository, times(1)).save(any());
     }
 
+    private RecruitmentBoardCreationRequest createTestRecruitmentBoardCreationRequest() {
+        MeetingPlaceRequest meetingPlaceRequest = createTestMeetingPlaceRequest();
+        return new RecruitmentBoardCreationRequest("제목", "본문", "달리기",
+                LocalDate.of(2023, 11, 11), meetingPlaceRequest);
+    }
+
+    private MeetingPlaceRequest createTestMeetingPlaceRequest() {
+        return new MeetingPlaceRequest(1.1, 1.2, "서울시 동작구 상도동 1-1");
+    }
+
     @Test
     @DisplayName("존재하지 않는 유저가 게시글 저장 시, 예외를 발생한다.")
     void writeFailedByNonexistentMember() {
         //given
         when(memberService.findByMemberId(anyLong())).thenThrow(new IllegalArgumentException("해당하는 유저가 존재하지 않습니다."));
 
-        RecruitmentBoardCreationRequest boardCreationRequest = new RecruitmentBoardCreationRequest("제목", "본문내용", "달리기",
-                LocalDate.of(2023, 2, 12), 1.1, 1.2, "서울시 동작구 상도동 1-1");
+        RecruitmentBoardCreationRequest boardCreationRequest = createTestRecruitmentBoardCreationRequest();
 
         //when, then
         assertThatThrownBy(() -> boardService.write(1L, boardCreationRequest))
@@ -174,16 +183,23 @@ class RecruitmentBoardServiceTest {
 
         Long memberId = 1L;
         Long boardId = 1L;
-        BoardModificationRequest boardModificationRequest = new BoardModificationRequest("변경 제목", "변경 본문",
-                "산책", LocalDate.of(2023, 12, 12));
+        BoardModificationRequest boardModificationRequest = createTestModificationRequest();
 
         //when
         RecruitmentBoardIdResponse actual = boardService.modify(memberId, boardId, boardModificationRequest);
 
         //then
         assertThat(actual.getBoardId()).isEqualTo(1L);
-        verify(recruitmentBoard, times(1)).modify(anyLong(), any(), any(), any(), any());
+        verify(recruitmentBoard, times(1)).modify(anyLong(), any(), any(), any(), any(), any());
     }
+
+    private BoardModificationRequest createTestModificationRequest() {
+        MeetingPlaceRequest meetingPlaceRequest = createTestMeetingPlaceRequest();
+
+        return new BoardModificationRequest("새로운 제목", "새로운 본문",
+                "산책", LocalDate.of(2023, 1, 1), meetingPlaceRequest);
+    }
+
 
     @Test
     @DisplayName("게시글의 모집을 마감한다.")

--- a/src/test/java/mokindang/jubging/project_backend/service/board/RecruitmentBoardServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/service/board/RecruitmentBoardServiceTest.java
@@ -9,7 +9,8 @@ import mokindang.jubging.project_backend.recruitment_board.domain.vo.*;
 import mokindang.jubging.project_backend.recruitment_board.repository.RecruitmentBoardRepository;
 import mokindang.jubging.project_backend.recruitment_board.service.RecruitmentBoardService;
 import mokindang.jubging.project_backend.recruitment_board.service.request.BoardModificationRequest;
-import mokindang.jubging.project_backend.recruitment_board.service.request.MeetingPlaceRequest;
+import mokindang.jubging.project_backend.recruitment_board.service.request.MeetingPlaceCreationRequest;
+import mokindang.jubging.project_backend.recruitment_board.service.request.MeetingPlaceModificationRequest;
 import mokindang.jubging.project_backend.recruitment_board.service.request.RecruitmentBoardCreationRequest;
 import mokindang.jubging.project_backend.recruitment_board.service.response.MultiBoardSelectResponse;
 import mokindang.jubging.project_backend.recruitment_board.service.response.RecruitmentBoardIdResponse;
@@ -73,13 +74,13 @@ class RecruitmentBoardServiceTest {
     }
 
     private RecruitmentBoardCreationRequest createTestRecruitmentBoardCreationRequest() {
-        MeetingPlaceRequest meetingPlaceRequest = createTestMeetingPlaceRequest();
+        MeetingPlaceCreationRequest meetingPlaceCreationRequest = createTestMeetingPlaceCreationRequest();
         return new RecruitmentBoardCreationRequest("제목", "본문", "달리기",
-                LocalDate.of(2023, 11, 11), meetingPlaceRequest);
+                LocalDate.of(2023, 11, 11), meetingPlaceCreationRequest);
     }
 
-    private MeetingPlaceRequest createTestMeetingPlaceRequest() {
-        return new MeetingPlaceRequest(1.1, 1.2, "서울시 동작구 상도동 1-1");
+    private MeetingPlaceCreationRequest createTestMeetingPlaceCreationRequest() {
+        return new MeetingPlaceCreationRequest(1.1, 1.2, "서울시 동작구 상도동 1-1");
     }
 
     @Test
@@ -194,10 +195,10 @@ class RecruitmentBoardServiceTest {
     }
 
     private BoardModificationRequest createTestModificationRequest() {
-        MeetingPlaceRequest meetingPlaceRequest = createTestMeetingPlaceRequest();
+        MeetingPlaceModificationRequest meetingPlaceModificationRequest = new MeetingPlaceModificationRequest(1.1, 1.2, "서울시 동작구 상도동 1-1");
 
         return new BoardModificationRequest("새로운 제목", "새로운 본문",
-                "산책", LocalDate.of(2023, 1, 1), meetingPlaceRequest);
+                "산책", LocalDate.of(2023, 1, 1), meetingPlaceModificationRequest);
     }
 
 
@@ -257,7 +258,7 @@ class RecruitmentBoardServiceTest {
         Pageable pageable = PageRequest.of(0, 2);
 
         //when
-        MultiBoardSelectResponse multiBoardSelectResponse = boardService.selectRegionBoards(1L, pageable);
+        MultiBoardSelectResponse multiBoardSelectResponse = boardService.selectRegionBoards(memberId, pageable);
 
         //then
         assertThat(multiBoardSelectResponse.getBoards()).hasSize(2);


### PR DESCRIPTION
# Refactor/#348/구인 게시글 수정 시 좌표와 상세 주소를 입력 받도록 변경

### 이슈 번호 : #348 

## 변경 사항
- 구인 게시글 수정 시 좌표와 상세 주소를 입력 받도록 변경
- 게시글 작성에 대한 Request DTO 내부에 장소 관련 부분을 DTO 로 한번 더 감쌈

## 그 외
- 

## 질문 사항
- 
