### PR TITLE
Refactor/#360/상세 게시글 조회 시 댓글 카운트 반환 로직 변경

### DIFF
--- a/src/main/java/mokindang/jubging/project_backend/comment/service/response/MultiCommentSelectionResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/service/response/MultiCommentSelectionResponse.java
@@ -1,15 +1,27 @@
 package mokindang.jubging.project_backend.comment.service.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
-@AllArgsConstructor
 public class MultiCommentSelectionResponse {
 
     @Schema(description = "댓글 리스트")
-    List<CommentSelectionResponse> comments;
+    private final List<CommentSelectionResponse> comments;
+
+    @Schema(description = "댓글과 대댓글의 총 갯수")
+    private final Long countOfCommentAndReplyComment;
+
+    public MultiCommentSelectionResponse(final List<CommentSelectionResponse> comments) {
+        this.comments = comments;
+        this.countOfCommentAndReplyComment = countReplyCommentAndComment(comments);
+    }
+
+    private Long countReplyCommentAndComment(final List<CommentSelectionResponse> comments) {
+        return (comments.stream()
+                .mapToLong(commentSelectionResponse -> commentSelectionResponse.getMultiReplyCommentSelectionResponse().countOfReplyComments)
+                .sum()) + 1;
+    }
 }

--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/RecruitmentBoardService.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/RecruitmentBoardService.java
@@ -34,19 +34,20 @@ public class RecruitmentBoardService {
     public RecruitmentBoardIdResponse write(final Long memberId, final RecruitmentBoardCreationRequest recruitmentBoardCreationRequest) {
         Member member = memberService.findByMemberId(memberId);
         LocalDateTime now = LocalDateTime.now();
-        Place meetingPlace = generateModificationPlace(recruitmentBoardCreationRequest.getMeetingPlaceCreationRequest());
+        Place meetingPlace = generateCreationPlace(recruitmentBoardCreationRequest.getMeetingPlaceCreationRequest());
         RecruitmentBoard recruitmentBoard = new RecruitmentBoard(now, member, recruitmentBoardCreationRequest.getStartingDate(),
                 recruitmentBoardCreationRequest.getActivityCategory(), meetingPlace, recruitmentBoardCreationRequest.getTitle(), recruitmentBoardCreationRequest.getContentBody());
         RecruitmentBoard savedRecruitmentBoard = recruitmentBoardRepository.save(recruitmentBoard);
         return new RecruitmentBoardIdResponse(savedRecruitmentBoard.getId());
     }
 
-    private Place generateModificationPlace(final MeetingPlaceCreationRequest meetingPlaceCreationRequest) {
+    private Place generateCreationPlace(final MeetingPlaceCreationRequest meetingPlaceCreationRequest) {
         Coordinate meetingSpot = new Coordinate(meetingPlaceCreationRequest.getLongitude(),
                 meetingPlaceCreationRequest.getLatitude());
         String meetingAddress = meetingPlaceCreationRequest.getMeetingAddress();
         return new Place(meetingSpot, meetingAddress);
     }
+
 
     public RecruitmentBoardSelectionResponse select(final Long memberId, final Long boardId) {
         RecruitmentBoard recruitmentBoard = findById(boardId);

--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/request/MeetingPlaceCreationRequest.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/request/MeetingPlaceCreationRequest.java
@@ -9,6 +9,7 @@ import javax.validation.constraints.NotNull;
 @Getter
 @RequiredArgsConstructor
 public class MeetingPlaceCreationRequest {
+
     @NotNull
     @Schema(description = "활동 장소 경도 좌표", example = "12.12312412")
     private final Double longitude;

--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/request/MeetingPlaceModificationRequest.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/request/MeetingPlaceModificationRequest.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 
-@Schema
 @Getter
 @RequiredArgsConstructor
 public class MeetingPlaceModificationRequest {


### PR DESCRIPTION
# Refactor/#360/상세 게시글 조회 시 댓글 카운트 반환 로직 변경

### 이슈 번호 : #360 

## 변경 사항
-    댓글 리스트 조회 요청 시 모든 댓글 갯수 + 대댓글 갯수 를 반환하도록함.

## 그 외
- BoardSerivce 내부 메서드 네이밍 리팩토링

## 질문 사항
- 
