### PR TITLE
docs : #374 swagger 설정 변경

### DIFF
--- a/src/main/java/mokindang/jubging/project_backend/authentication/controller/AuthenticationControllerSwagger.java
+++ b/src/main/java/mokindang/jubging/project_backend/authentication/controller/AuthenticationControllerSwagger.java
@@ -28,7 +28,6 @@ public interface AuthenticationControllerSwagger {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "카카오 로그안 완료",
                     headers = {@Header(name = AUTHORIZATION),
-                            @Header(name = SET_COOKIE, description = "refreshToken")
                     }, content = @Content(schema = @Schema(implementation = LoginResponse.class))),
     })
     ResponseEntity<LoginResponse> kakaoLogin(@RequestBody AuthorizationCodeRequest authorizationCodeRequest);
@@ -38,9 +37,7 @@ public interface AuthenticationControllerSwagger {
     })
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Refresh 토큰 재발급 완료",
-                    headers = {@Header(name = AUTHORIZATION),
-                            @Header(name = SET_COOKIE, description = "refreshToken")
-                    }),
+                    headers = {@Header(name = SET_COOKIE, description = "refreshToken")}),
             @ApiResponse(responseCode = "401", description = "존재 하지 않는 Refresh 토큰 입력\t\n" +
                     "Refresh 토큰이 만료됨", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "400", description = "refresh token 이 null 이나 공백으로 입력 \t\n" +
@@ -50,7 +47,6 @@ public interface AuthenticationControllerSwagger {
 
     @Operation(summary = "회원 로그아웃 요청", parameters = {
             @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true),
-            @Parameter(name = SET_COOKIE, description = "refreshToken", in = ParameterIn.COOKIE, required = true)
     })
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "회원 로그아웃 완료")

--- a/src/main/java/mokindang/jubging/project_backend/comment/controller/CommentControllerSwagger.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/controller/CommentControllerSwagger.java
@@ -22,14 +22,12 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.http.HttpHeaders.SET_COOKIE;
 
 @Tag(name = "댓글 서비스", description = "댓글 관련 api")
 public interface CommentControllerSwagger {
 
     @Operation(summary = "게시글에 새 댓글 작성", parameters = {
-            @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true),
-            @Parameter(name = SET_COOKIE, description = "refreshToken", in = ParameterIn.COOKIE, required = true)
+            @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true)
     }
     )
     @ApiResponses(value = {
@@ -42,13 +40,12 @@ public interface CommentControllerSwagger {
     })
     @PostMapping("/{board-type}/{boardId}/comments")
     ResponseEntity<BoardIdResponse> addCommentToBoard(@Parameter(hidden = true) @Login final Long memberId,
-                                                      @Parameter(hidden = true) @PathVariable("board-type") final BoardType boardType,
+                                                      @PathVariable("board-type") final BoardType boardType,
                                                       @PathVariable final Long boardId,
                                                       @Valid @RequestBody final CommentCreationRequest commentCreationRequest);
 
     @Operation(summary = "게시글의 댓글 목록 조회", parameters = {
-            @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true),
-            @Parameter(name = SET_COOKIE, description = "refreshToken", in = ParameterIn.COOKIE, required = true)
+            @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true)
     }
     )
     @ApiResponses(value = {
@@ -64,8 +61,7 @@ public interface CommentControllerSwagger {
                                                                  @PathVariable final Long boardId);
 
     @Operation(summary = "댓글 삭제", parameters = {
-            @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true),
-            @Parameter(name = SET_COOKIE, description = "refreshToken", in = ParameterIn.COOKIE, required = true)
+            @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true)
     }
     )
     @ApiResponses(value = {
@@ -78,9 +74,7 @@ public interface CommentControllerSwagger {
     ResponseEntity<Object> removeComment(@Parameter(hidden = true) @Login Long memberId, @PathVariable final Long commentId);
 
     @Operation(summary = "대댓글 생성", parameters = {
-            @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true),
-            @Parameter(name = SET_COOKIE, description = "refreshToken", in = ParameterIn.COOKIE, required = true)
-    }
+            @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true)}
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "대댓글 생성 완료"),
@@ -95,8 +89,7 @@ public interface CommentControllerSwagger {
                                                       ReplyCommentCreationRequest replyCommentCreationRequest);
 
     @Operation(summary = "대댓글 삭제", parameters = {
-            @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true),
-            @Parameter(name = SET_COOKIE, description = "refreshToken", in = ParameterIn.COOKIE, required = true)
+            @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true)
     }
     )
     @ApiResponses(value = {

--- a/src/main/java/mokindang/jubging/project_backend/comment/service/request/CommentCreationRequest.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/service/request/CommentCreationRequest.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CommentCreationRequest {
 
-    @Schema(name = "댓글 본문 내용", example = "예시 댓글 입니다.")
+    @Schema(description = "댓글 본문 내용", example = "예시 댓글 입니다.")
     private String commentBody;
 }

--- a/src/main/java/mokindang/jubging/project_backend/member/controller/MemberControllerSwagger.java
+++ b/src/main/java/mokindang/jubging/project_backend/member/controller/MemberControllerSwagger.java
@@ -22,18 +22,16 @@ import org.springframework.web.bind.annotation.RequestBody;
 import javax.validation.Valid;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.http.HttpHeaders.SET_COOKIE;
 
 @Tag(name = "회원", description = "회원 관련 api")
 public interface MemberControllerSwagger {
 
     @Operation(summary = "회원의 지역 변경", parameters = {
-            @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true),
-            @Parameter(name = SET_COOKIE, description = "refreshToken", in = ParameterIn.COOKIE, required = true)}
+            @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true)}
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "변경완료"),
-            @ApiResponse(responseCode = "400", description = "유효하지 않은 유저 \t\n"+
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 유저 \t\n" +
                     "입력 받은 위도 경도가 대한민국이 아닌 경우",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })

--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/controller/RecruitmentBoardControllerSwagger.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/controller/RecruitmentBoardControllerSwagger.java
@@ -20,14 +20,12 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.http.HttpHeaders.SET_COOKIE;
 
 @Tag(name = "구인 게시판", description = "구인 게시판 관련 api")
 public interface RecruitmentBoardControllerSwagger {
 
     @Operation(summary = "새글작성", parameters = {
-            @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true),
-            @Parameter(name = SET_COOKIE, description = "refreshToken", in = ParameterIn.COOKIE, required = true)}
+            @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true)}
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "새글작성"),
@@ -42,7 +40,7 @@ public interface RecruitmentBoardControllerSwagger {
     @Operation(summary = "게시글 조회", parameters = {
             @Parameter(name = "boardId", description = "Board 의 id", in = ParameterIn.PATH),
             @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true),
-            @Parameter(name = SET_COOKIE, description = "refreshToken", in = ParameterIn.COOKIE, required = true)}
+    }
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "글 조회"),
@@ -63,7 +61,7 @@ public interface RecruitmentBoardControllerSwagger {
     @Operation(summary = "게시글 삭제", parameters = {
             @Parameter(name = "boardId", description = "삭제할 Board 의 Id", in = ParameterIn.PATH),
             @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true),
-            @Parameter(name = SET_COOKIE, description = "refreshToken", in = ParameterIn.COOKIE, required = true)})
+    })
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "게시글 삭제 완료",
                     content = @Content(schema = @Schema(implementation = RecruitmentBoardIdResponse.class))),
@@ -78,7 +76,7 @@ public interface RecruitmentBoardControllerSwagger {
     @Operation(summary = "게시글 수정", parameters = {
             @Parameter(name = "boardId", description = "수정할 Board 의 Id", in = ParameterIn.PATH),
             @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true),
-            @Parameter(name = SET_COOKIE, description = "refreshToken", in = ParameterIn.COOKIE, required = true)})
+    })
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "게시글 수정 완료",
                     content = @Content(schema = @Schema(implementation = RecruitmentBoardIdResponse.class))),
@@ -93,14 +91,14 @@ public interface RecruitmentBoardControllerSwagger {
 
     @Operation(summary = "지역 게시글 리스트 게시글 조회", parameters = {
             @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true),
-            @Parameter(name = SET_COOKIE, description = "refreshToken", in = ParameterIn.COOKIE, required = true)}
+    }
     )
     @GetMapping("/my-region")
-    ResponseEntity<MultiBoardSelectionResponse> selectRegionBoards(@Login final Long memberId, final Pageable pageable);
+    ResponseEntity<MultiBoardSelectionResponse> selectRegionBoards(@Parameter(hidden = true) @Login final Long memberId, final Pageable pageable);
 
     @Operation(summary = "장소 마커 리스트 조회", parameters = {
             @Parameter(name = AUTHORIZATION, description = "access token", in = ParameterIn.HEADER, required = true),
-            @Parameter(name = SET_COOKIE, description = "refreshToken", in = ParameterIn.COOKIE, required = true)})
+    })
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "게시글 마커 조회 완료",
                     content = @Content(schema = @Schema(implementation = MultiBoardPlaceSelectionResponse.class))),
@@ -108,7 +106,7 @@ public interface RecruitmentBoardControllerSwagger {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping("/places")
-    ResponseEntity<MultiBoardPlaceSelectionResponse> selectPlacesOfRegionBoards(@Login final Long memberId, final Pageable pageable);
+    ResponseEntity<MultiBoardPlaceSelectionResponse> selectPlacesOfRegionBoards(@Parameter(hidden = true) @Login final Long memberId, final Pageable pageable);
 
     @Operation(summary = "모집 게시글 갯수 상위 5개 지역")
     @ApiResponses(value = {


### PR DESCRIPTION
#  swagger 설정 변경

### 이슈 번호 : #374

## 변경 사항
-    스웨거 api  콜 불가한 부분 해결
    - `refreshToken` 을 사용하지 않는 요청에 대해서 파라미터로 입력을 받도록 설정하여, 스웨거에서 api 요청시 refreshToken 이 존재하지 않아 서버로 요청을 보내지 못하는 문제 수정
    - 수정 방법 : Swagger Controller 에서 `refreshToken` 요청 부분 제거

## 그 외
- 

## 질문 사항
- 
