### PR TITLE
Feature/#392/플로깅 참여 여부 확인 기능 구현

### DIFF
--- a/src/main/java/mokindang/jubging/project_backend/comment/controller/CommentController.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/controller/CommentController.java
@@ -9,7 +9,6 @@ import mokindang.jubging.project_backend.comment.service.request.ReplyCommentCre
 import mokindang.jubging.project_backend.comment.service.response.BoardIdResponse;
 import mokindang.jubging.project_backend.comment.service.response.CommentIdResponse;
 import mokindang.jubging.project_backend.comment.service.response.MultiCommentSelectionResponse;
-import mokindang.jubging.project_backend.exception.custom.ForbiddenException;
 import mokindang.jubging.project_backend.web.argumentresolver.Login;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -41,14 +40,9 @@ public class CommentController implements CommentControllerSwagger {
                                                                         @PathVariable("board-type") final BoardType boardType,
                                                                         @PathVariable final Long boardId) {
         log.info("memberId = {} 의 게시판 {} boardId = {} 에 대한 댓글 조회 요청", memberId, boardType.toString(), boardId);
-        try {
             MultiCommentSelectionResponse multiCommentSelectionResponse = commentService.selectComments(memberId, boardType, boardId);
             return ResponseEntity.ok()
                     .body(multiCommentSelectionResponse);
-        } catch (ForbiddenException e) {
-            return ResponseEntity.noContent()
-                    .build();
-        }
     }
 
     @DeleteMapping("/comments/{commentId}")

--- a/src/main/java/mokindang/jubging/project_backend/comment/domain/Comment.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/domain/Comment.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mokindang.jubging.project_backend.certification_board.domain.CertificationBoard;
 import mokindang.jubging.project_backend.comment.domain.vo.CommentBody;
+import mokindang.jubging.project_backend.comment.service.BoardType;
 import mokindang.jubging.project_backend.exception.custom.ForbiddenException;
 import mokindang.jubging.project_backend.member.domain.Member;
 import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
@@ -126,6 +127,16 @@ public class Comment {
     public void addReplyComment(final ReplyComment replyComment) {
         this.replyComments
                 .add(replyComment);
+    }
+
+    public boolean isWriterOfBoard(final BoardType boardType) {
+        if (boardType == BoardType.RECRUITMENT_BOARD) {
+            recruitmentBoard.isSameWriterId(this.writer.getId());
+        }
+        if (boardType == BoardType.CERTIFICATION_BOARD) {
+            certificationBoard.isSameWriterId(this.writer.getId());
+        }
+        throw new IllegalArgumentException("존재 하지 않는 게시판에 대한 접근입니다.");
     }
 
     @Override

--- a/src/main/java/mokindang/jubging/project_backend/comment/domain/Comment.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/domain/Comment.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mokindang.jubging.project_backend.certification_board.domain.CertificationBoard;
 import mokindang.jubging.project_backend.comment.domain.vo.CommentBody;
-import mokindang.jubging.project_backend.comment.service.BoardType;
 import mokindang.jubging.project_backend.exception.custom.ForbiddenException;
 import mokindang.jubging.project_backend.member.domain.Member;
 import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
@@ -90,7 +89,7 @@ public class Comment {
         return replyComments.size();
     }
 
-    public void modify(final Long memberId,final String commentBody, final LocalDateTime now) {
+    public void modify(final Long memberId, final String commentBody, final LocalDateTime now) {
         validatePermission(memberId);
         this.commentBody = new CommentBody(commentBody);
         this.lastModifiedDateTime = now;
@@ -127,16 +126,6 @@ public class Comment {
     public void addReplyComment(final ReplyComment replyComment) {
         this.replyComments
                 .add(replyComment);
-    }
-
-    public boolean isWriterOfBoard(final BoardType boardType) {
-        if (boardType == BoardType.RECRUITMENT_BOARD) {
-            recruitmentBoard.isSameWriterId(this.writer.getId());
-        }
-        if (boardType == BoardType.CERTIFICATION_BOARD) {
-            certificationBoard.isSameWriterId(this.writer.getId());
-        }
-        throw new IllegalArgumentException("존재 하지 않는 게시판에 대한 접근입니다.");
     }
 
     @Override

--- a/src/main/java/mokindang/jubging/project_backend/comment/service/CommentService.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/service/CommentService.java
@@ -68,21 +68,28 @@ public class CommentService {
             RecruitmentBoard board = recruitmentBoardService.findByIdWithOptimisticLock(boardId);
             boolean writingCommentPermission = board.isSameRegion(member.getRegion());
             boolean isWriterParticipatedIn = board.isParticipatedIn(memberId);
-            return new MultiCommentSelectionResponse(convertToCommentSelectionResponse(memberId, commentsByRecruitmentBoard, boardType, isWriterParticipatedIn),
+            return new MultiCommentSelectionResponse(convertToRecruitmentBoardCommentSelectionResponse(memberId, commentsByRecruitmentBoard, board, isWriterParticipatedIn),
                     writingCommentPermission);
         }
 
         if (boardType == BoardType.CERTIFICATION_BOARD) {
             List<Comment> commentsByCertificationBoard = commentRepository.findCommentsByCertificationBoardId(boardId);
-            return new MultiCommentSelectionResponse(convertToCommentSelectionResponse(memberId, commentsByCertificationBoard, boardType, false),
+            CertificationBoard board = certificationBoardService.findById(boardId);
+            return new MultiCommentSelectionResponse(convertToCertificationBoardCommentSelectionResponse2(memberId, commentsByCertificationBoard, board),
                     true);
         }
         throw new IllegalArgumentException("존재 하지 않는 게시판에 대한 접근입니다.");
     }
 
-    private List<CommentSelectionResponse> convertToCommentSelectionResponse(final Long memberId, final List<Comment> commentsByRecruitmentBoard, final BoardType boardType, final boolean isWriterParticipatedIn) {
+    private List<CommentSelectionResponse> convertToRecruitmentBoardCommentSelectionResponse(final Long memberId, final List<Comment> commentsByRecruitmentBoard, final RecruitmentBoard board, final boolean isWriterParticipatedIn) {
         return commentsByRecruitmentBoard.stream()
-                .map(comment -> new CommentSelectionResponse(comment, memberId, boardType, isWriterParticipatedIn))
+                .map(comment -> new CommentSelectionResponse(comment, memberId, board.isSameWriterId(comment.getWriter().getId()), isWriterParticipatedIn))
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    private List<CommentSelectionResponse> convertToCertificationBoardCommentSelectionResponse2(final Long memberId, final List<Comment> commentsByRecruitmentBoard, final CertificationBoard board) {
+        return commentsByRecruitmentBoard.stream()
+                .map(comment -> new CommentSelectionResponse(comment, memberId, board.isSameWriterId(comment.getWriter().getId()), false))
                 .collect(Collectors.toUnmodifiableList());
     }
 

--- a/src/main/java/mokindang/jubging/project_backend/comment/service/CommentService.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/service/CommentService.java
@@ -44,14 +44,14 @@ public class CommentService {
         Member writer = memberService.findByMemberId(memberId);
         LocalDateTime now = LocalDateTime.now();
 
-        if (boardType.equals(BoardType.RECRUITMENT_BOARD)) {
+        if (boardType == BoardType.RECRUITMENT_BOARD) {
             RecruitmentBoard board = recruitmentBoardService.findByIdWithOptimisticLock(boardId);
             Comment comment = Comment.createOnRecruitmentBoardWith(board, commentCreationRequest.getCommentBody(), writer, now);
             commentRepository.save(comment);
             return new BoardIdResponse(boardId);
         }
 
-        if (boardType.equals(BoardType.CERTIFICATION_BOARD)) {
+        if (boardType == BoardType.CERTIFICATION_BOARD) {
             CertificationBoard board = certificationBoardService.findById(boardId);
             Comment comment = Comment.createOnCertificationBoardWith(board, commentCreationRequest.getCommentBody(), writer, now);
             commentRepository.save(comment);
@@ -62,22 +62,27 @@ public class CommentService {
 
     @Transactional
     public MultiCommentSelectionResponse selectComments(final Long memberId, final BoardType boardType, final Long boardId) {
-        if (boardType.equals(BoardType.RECRUITMENT_BOARD)) {
+        if (boardType == BoardType.RECRUITMENT_BOARD) {
             List<Comment> commentsByRecruitmentBoard = commentRepository.findCommentsByRecruitmentBoardId(boardId);
-            boolean writingCommentPermission = recruitmentBoardService.hasWritingCommentPermission(memberId, boardId);
-            return new MultiCommentSelectionResponse(convertToCommentSelectionResponse(memberId, commentsByRecruitmentBoard), writingCommentPermission);
+            Member member = memberService.findByMemberId(memberId);
+            RecruitmentBoard board = recruitmentBoardService.findByIdWithOptimisticLock(boardId);
+            boolean writingCommentPermission = board.isSameRegion(member.getRegion());
+            boolean isWriterParticipatedIn = board.isParticipatedIn(memberId);
+            return new MultiCommentSelectionResponse(convertToCommentSelectionResponse(memberId, commentsByRecruitmentBoard, boardType, isWriterParticipatedIn),
+                    writingCommentPermission);
         }
 
-        if (boardType.equals(BoardType.CERTIFICATION_BOARD)) {
+        if (boardType == BoardType.CERTIFICATION_BOARD) {
             List<Comment> commentsByCertificationBoard = commentRepository.findCommentsByCertificationBoardId(boardId);
-            return new MultiCommentSelectionResponse(convertToCommentSelectionResponse(memberId, commentsByCertificationBoard), true);
+            return new MultiCommentSelectionResponse(convertToCommentSelectionResponse(memberId, commentsByCertificationBoard, boardType, false),
+                    true);
         }
         throw new IllegalArgumentException("존재 하지 않는 게시판에 대한 접근입니다.");
     }
 
-    private List<CommentSelectionResponse> convertToCommentSelectionResponse(final Long memberId, final List<Comment> commentsByRecruitmentBoard) {
+    private List<CommentSelectionResponse> convertToCommentSelectionResponse(final Long memberId, final List<Comment> commentsByRecruitmentBoard, final BoardType boardType, final boolean isWriterParticipatedIn) {
         return commentsByRecruitmentBoard.stream()
-                .map(comment -> new CommentSelectionResponse(comment, memberId))
+                .map(comment -> new CommentSelectionResponse(comment, memberId, boardType, isWriterParticipatedIn))
                 .collect(Collectors.toUnmodifiableList());
     }
 

--- a/src/main/java/mokindang/jubging/project_backend/comment/service/response/CommentSelectionResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/service/response/CommentSelectionResponse.java
@@ -3,6 +3,7 @@ package mokindang.jubging.project_backend.comment.service.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import mokindang.jubging.project_backend.comment.domain.Comment;
+import mokindang.jubging.project_backend.comment.service.BoardType;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -38,7 +39,13 @@ public class CommentSelectionResponse {
     @Schema(description = "대댓글 목록")
     MultiReplyCommentSelectionResponse multiReplyCommentSelectionResponse;
 
-    public CommentSelectionResponse(final Comment comment, final Long memberId) {
+    @Schema(description = "해당 댓글이 게시글의 작성자인지 여부")
+    private final boolean writerOfBoard;
+
+    @Schema(description = "댓글의 작성자가 플로깅에 참여한 상태 여부")
+    private final boolean writerParticipatedIn;
+
+    public CommentSelectionResponse(final Comment comment, final Long memberId, final BoardType boardType, final boolean writerParticipatedIn) {
         this.commentId = comment.getId();
         this.commentBody = comment.getCommentBody()
                 .getBody();
@@ -48,8 +55,10 @@ public class CommentSelectionResponse {
         this.firstFourLettersOfEmail = comment.getFirstFourDigitsOfWriterEmail();
         this.writerProfileImageUrl = comment.getWriterProfileImageUrl();
         this.mine = comment.isSameWriterId(memberId);
-        List<ReplyCommentSelectionResponse> replyCommentSelectionResponses = generateReplyCommentSelectionResponses(comment,memberId);
+        List<ReplyCommentSelectionResponse> replyCommentSelectionResponses = generateReplyCommentSelectionResponses(comment, memberId);
         this.multiReplyCommentSelectionResponse = new MultiReplyCommentSelectionResponse(replyCommentSelectionResponses);
+        this.writerOfBoard = comment.isWriterOfBoard(boardType);
+        this.writerParticipatedIn = writerParticipatedIn;
     }
 
     private  List<ReplyCommentSelectionResponse> generateReplyCommentSelectionResponses(final Comment comment, final Long memberId) {

--- a/src/main/java/mokindang/jubging/project_backend/comment/service/response/CommentSelectionResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/service/response/CommentSelectionResponse.java
@@ -3,7 +3,6 @@ package mokindang.jubging.project_backend.comment.service.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import mokindang.jubging.project_backend.comment.domain.Comment;
-import mokindang.jubging.project_backend.comment.service.BoardType;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -45,7 +44,7 @@ public class CommentSelectionResponse {
     @Schema(description = "댓글의 작성자가 플로깅에 참여한 상태 여부")
     private final boolean writerParticipatedIn;
 
-    public CommentSelectionResponse(final Comment comment, final Long memberId, final BoardType boardType, final boolean writerParticipatedIn) {
+    public CommentSelectionResponse(final Comment comment, final Long memberId, final boolean isWriterOfBoard, final boolean writerParticipatedIn) {
         this.commentId = comment.getId();
         this.commentBody = comment.getCommentBody()
                 .getBody();
@@ -57,7 +56,7 @@ public class CommentSelectionResponse {
         this.mine = comment.isSameWriterId(memberId);
         List<ReplyCommentSelectionResponse> replyCommentSelectionResponses = generateReplyCommentSelectionResponses(comment, memberId);
         this.multiReplyCommentSelectionResponse = new MultiReplyCommentSelectionResponse(replyCommentSelectionResponses);
-        this.writerOfBoard = comment.isWriterOfBoard(boardType);
+        this.writerOfBoard = isWriterOfBoard;
         this.writerParticipatedIn = writerParticipatedIn;
     }
 

--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/domain/RecruitmentBoard.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/domain/RecruitmentBoard.java
@@ -10,14 +10,16 @@ import mokindang.jubging.project_backend.member.domain.vo.Region;
 import mokindang.jubging.project_backend.recruitment_board.domain.participation.Participation;
 import mokindang.jubging.project_backend.recruitment_board.domain.vo.ContentBody;
 import mokindang.jubging.project_backend.recruitment_board.domain.vo.ParticipationCount;
-import mokindang.jubging.project_backend.recruitment_board.domain.vo.place.Place;
 import mokindang.jubging.project_backend.recruitment_board.domain.vo.StartingDate;
 import mokindang.jubging.project_backend.recruitment_board.domain.vo.Title;
+import mokindang.jubging.project_backend.recruitment_board.domain.vo.place.Place;
 
 import javax.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 @Getter
 @Entity
@@ -171,6 +173,11 @@ public class RecruitmentBoard {
         if (this.participationList.contains(participation)) {
             throw new IllegalArgumentException("이미 참여가 된 상태입니다.");
         }
+    }
+
+    public boolean isParticipatedIn(final Long memberId) {
+        return participationList.stream()
+                .anyMatch(participation -> participation.isParticipatedIn(memberId));
     }
 
     @Override

--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/domain/participation/Participation.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/domain/participation/Participation.java
@@ -25,9 +25,15 @@ public class Participation {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    public Participation(final RecruitmentBoard recruitmentBoard, final Member writer) {
+    public Participation(final RecruitmentBoard recruitmentBoard, final Member member) {
         this.recruitmentBoard = recruitmentBoard;
-        this.member = writer;
+        this.member = member;
+    }
+
+    public boolean isParticipatedIn(final Long memberId) {
+        return this.member
+                .getId()
+                .equals(memberId);
     }
 
     @Override
@@ -35,7 +41,7 @@ public class Participation {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Participation that = (Participation) o;
-        return Objects.equals(recruitmentBoard, that.recruitmentBoard) && Objects.equals(member, that.member);
+        return Objects.equals(recruitmentBoard.getId(), that.recruitmentBoard.getId()) && Objects.equals(member.getId(), that.member.getId());
     }
 
     @Override

--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/domain/vo/ParticipationCount.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/domain/vo/ParticipationCount.java
@@ -20,8 +20,6 @@ public class ParticipationCount {
     @Column(name = "max_count_of_participation")
     private int max;
 
-
-
     public static ParticipationCount createDefaultParticipationCount(final int max) {
         return new ParticipationCount(max);
     }

--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/RecruitmentBoardService.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/RecruitmentBoardService.java
@@ -118,12 +118,6 @@ public class RecruitmentBoardService {
         return new MultiBoardPlaceSelectionResponse(boardPlaceMarkerResponses, recruitmentBoards.hasNext());
     }
 
-    public boolean hasWritingCommentPermission(final Long memberId, final Long boardId) {
-        Member member = memberService.findByMemberId(memberId);
-        RecruitmentBoard board = findByIdWithOptimisticLock(boardId);
-        return board.isSameRegion(member.getRegion());
-    }
-
     public MultiRegionCountingChartResponse getRegionCountingChart(final Pageable pageable) {
         Slice<Region> regionBoardsCountingChart = recruitmentBoardRepository.getRegionBoardsCountingChart(pageable);
         List<RegionCountingChartResponse> regionCountingChartResponses = regionBoardsCountingChart.stream()

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -29,12 +29,22 @@ INSERT INTO recruitment_board (MEMBER_ID, CREATING_DATE_TIME, STARTING_DATE, ACT
 VALUES (1, '2023-3-9-12-0', '2023-3-15', 'RUNNING', '제목', '본문내용', '동작구', true, 1.1, 1.2, '서울시 동작구 상도동 1-1',1,8, 1);
 
 INSERT INTO recruitment_board (MEMBER_ID, CREATING_DATE_TIME, STARTING_DATE, ACTIVITY_CATEGORY, TITLE, CONTENT_BODY,
-                               REGION, ON_RECRUITMENT, longitude_point, latitude_point, address, count_of_participation, max_count_of_participation,version)
+                               REGION, ON_RECRUITMENT, longitude_point, latitude_point, address, count_of_participation, max_count_of_participation, version)
 VALUES (1, '2023-3-9-12-0', '2023-3-16', 'RUNNING', '제목2', '본문내용2', '동작구', true, 1.3, 1.4, '서울시 동작구 상도동 1-2',1,8,1);
 
+INSERT INTO certification_board (MEMBER_ID, CREATED_DATE_TIME, modifiedtime, TITLE, CONTENT_BODY)
+VALUES (1, '2023-3-9-12-0', '2023-3-9-12-0', '인증제목1', '인증본문1');
+
+
+--댓글
 INSERT INTO comment (body, created_date_time, last_modified_date_time, certification_board_id, recruitment_board_id,
                      member_id)
 VALUES ('테스트 댓글', '2023-3-10-11-0', '2023-3-10-11-0', null, 1, 1);
+
+INSERT INTO comment (body, created_date_time, last_modified_date_time, certification_board_id, recruitment_board_id,
+                     member_id)
+VALUES ('테스트 댓글', '2023-3-10-11-0', '2023-3-10-11-0', 1, null, 1);
+
 
 --대댓글
 INSERT INTO reply_comment (reply_comment_id, created_date_time, last_modified_date_time, body, comment_id, member_id)

--- a/src/test/java/mokindang/jubging/project_backend/comment/controller/CommentControllerTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/comment/controller/CommentControllerTest.java
@@ -2,13 +2,15 @@ package mokindang.jubging.project_backend.comment.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import mokindang.jubging.project_backend.comment.domain.Comment;
-import mokindang.jubging.project_backend.comment.domain.ReplyComment;
 import mokindang.jubging.project_backend.comment.domain.vo.CommentBody;
 import mokindang.jubging.project_backend.comment.service.BoardType;
 import mokindang.jubging.project_backend.comment.service.CommentService;
 import mokindang.jubging.project_backend.comment.service.request.CommentCreationRequest;
 import mokindang.jubging.project_backend.comment.service.request.ReplyCommentCreationRequest;
-import mokindang.jubging.project_backend.comment.service.response.*;
+import mokindang.jubging.project_backend.comment.service.response.BoardIdResponse;
+import mokindang.jubging.project_backend.comment.service.response.CommentIdResponse;
+import mokindang.jubging.project_backend.comment.service.response.CommentSelectionResponse;
+import mokindang.jubging.project_backend.comment.service.response.MultiCommentSelectionResponse;
 import mokindang.jubging.project_backend.web.jwt.TokenManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -65,14 +67,14 @@ class CommentControllerTest {
     }
 
     @Test
-    @DisplayName("입력받은 BoardType 과 boardId 에 해당하는 댓글과 댓글 리스트를 반환한다.")
+    @DisplayName("입력받은 BoardType 과 boardId 에 해당하는 댓글과 댓글 리스트를 반환한다." +
+            "이때 각 댓글에 게시판의 작성자 유무와, 활동 참여 여부를 함께 반환한다.")
     void selectComments() throws Exception {
         //given
-        CommentSelectionResponse commentSelectionResponse = new CommentSelectionResponse(createMockedComment(),
-                1L);
+        CommentSelectionResponse commentSelectionResponse = new CommentSelectionResponse(createMockedComment(), 1L,
+                BoardType.RECRUITMENT_BOARD, true);
         when(commentService.selectComments(anyLong(), any(BoardType.class), anyLong()))
                 .thenReturn(new MultiCommentSelectionResponse(List.of(commentSelectionResponse), true));
-
 
         //when
         ResultActions actual = mockMvc.perform(get("/api/{board-type}/{boardId}/comments",
@@ -88,7 +90,9 @@ class CommentControllerTest {
                 .andExpect(jsonPath("$.comments[0].writerAlias").value("댓글작성자"))
                 .andExpect(jsonPath("$.comments[0].firstFourLettersOfEmail").value("test"))
                 .andExpect(jsonPath("$.comments[0].writerProfileImageUrl").value("test_url"))
-                .andExpect(jsonPath("$.comments[0].multiReplyCommentSelectionResponse.replyComments").exists());
+                .andExpect(jsonPath("$.comments[0].multiReplyCommentSelectionResponse.replyComments").exists())
+                .andExpect(jsonPath("$.comments[0].writerOfBoard").value("true"))
+                .andExpect(jsonPath("$.comments[0].writerParticipatedIn").value("true"));
     }
 
     private Comment createMockedComment() {
@@ -100,6 +104,7 @@ class CommentControllerTest {
         when(comment.getWriterAlias()).thenReturn("댓글작성자");
         when(comment.getFirstFourDigitsOfWriterEmail()).thenReturn("test");
         when(comment.getWriterProfileImageUrl()).thenReturn("test_url");
+        when(comment.isWriterOfBoard(any(BoardType.class))).thenReturn(true);
         return comment;
     }
 
@@ -108,7 +113,7 @@ class CommentControllerTest {
     void deleteComment() throws Exception {
         //given
         doNothing().when(commentService)
-                .deleteComment(anyLong(),anyLong());
+                .deleteComment(anyLong(), anyLong());
 
         //when
         ResultActions actual = mockMvc.perform(delete("/api/comments/{commentId}",
@@ -145,7 +150,7 @@ class CommentControllerTest {
         ReplyCommentCreationRequest replyCommentCreationRequest = new ReplyCommentCreationRequest("대댓글 본문");
         //when
         ResultActions actual = mockMvc.perform(post("/api/comments/{commentId}/reply-comment", 1L)
-                        .content(objectMapper.writeValueAsString(replyCommentCreationRequest))
+                .content(objectMapper.writeValueAsString(replyCommentCreationRequest))
                 .contentType(MediaType.APPLICATION_JSON));
 
         //then
@@ -176,7 +181,7 @@ class CommentControllerTest {
     void deleteReplyComment() throws Exception {
         //given
         doNothing().when(commentService)
-                .deleteReplyComment(anyLong(),anyLong());
+                .deleteReplyComment(anyLong(), anyLong());
 
         //when
         ResultActions actual = mockMvc.perform(delete("/api/comments/reply-comments/{replyCommentId}",
@@ -186,12 +191,13 @@ class CommentControllerTest {
         //then
         actual.andExpect(status().isNoContent());
     }
+
     @Test
     @DisplayName("대댓글 삭제 요청 시 , 입력 받은 replyCommentId 에 해당하는 대댓글이 존재하지 않는 경우 후 HTTP 상태코드 400 를 반환한다.")
     void deleteFailedByNoneExistReplyComment() throws Exception {
         //given
         doThrow(new IllegalArgumentException("존재하지 않는 대댓글 입니다.")).when(commentService)
-                .deleteReplyComment(anyLong(),anyLong());
+                .deleteReplyComment(anyLong(), anyLong());
 
         //when
         ResultActions actual = mockMvc.perform(delete("/api/comments/reply-comments/{replyCommentId}",

--- a/src/test/java/mokindang/jubging/project_backend/comment/controller/CommentControllerTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/comment/controller/CommentControllerTest.java
@@ -72,7 +72,7 @@ class CommentControllerTest {
     void selectComments() throws Exception {
         //given
         CommentSelectionResponse commentSelectionResponse = new CommentSelectionResponse(createMockedComment(), 1L,
-                BoardType.RECRUITMENT_BOARD, true);
+                true, true);
         when(commentService.selectComments(anyLong(), any(BoardType.class), anyLong()))
                 .thenReturn(new MultiCommentSelectionResponse(List.of(commentSelectionResponse), true));
 
@@ -104,7 +104,6 @@ class CommentControllerTest {
         when(comment.getWriterAlias()).thenReturn("댓글작성자");
         when(comment.getFirstFourDigitsOfWriterEmail()).thenReturn("test");
         when(comment.getWriterProfileImageUrl()).thenReturn("test_url");
-        when(comment.isWriterOfBoard(any(BoardType.class))).thenReturn(true);
         return comment;
     }
 

--- a/src/test/java/mokindang/jubging/project_backend/comment/domain/CommentTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/comment/domain/CommentTest.java
@@ -13,8 +13,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.annotation.Rollback;
 
-import java.time.LocalDate;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,14 +26,20 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Rollback
+@DataJpaTest
 @ExtendWith(MockitoExtension.class)
 class CommentTest {
+
+    @PersistenceContext
+    private EntityManager em;
 
     @Test
     @DisplayName("작성 일시, 작성자, 댓글 본문을 입력받아 댓글을 생성한다.")
     void create() {
         //given
-        RecruitmentBoard recruitmentBoard = createRecruitmentBoard();
+        RecruitmentBoard recruitmentBoard = findTestRecruitmentBoard();
         LocalDateTime now = LocalDateTime.of(2023, 4, 8, 16, 48);
         Member writer = new Member("test@email.com", "test");
         String commentBodyValue = "안녕하세요.";
@@ -38,12 +48,8 @@ class CommentTest {
         assertThatCode(() -> Comment.createOnRecruitmentBoardWith(recruitmentBoard, commentBodyValue, writer, now)).doesNotThrowAnyException();
     }
 
-    private RecruitmentBoard createRecruitmentBoard() {
-        LocalDateTime now = LocalDateTime.of(2023, 11, 12, 0, 0, 0);
-        Member writer = new Member("test1@email.com", "test");
-        writer.updateRegion("동작구");
-        return new RecruitmentBoard(now, writer, LocalDate.of(2025, 2, 11), "달리기",
-                createTestPlace(), "제목", "본문내용", 8);
+    private RecruitmentBoard findTestRecruitmentBoard() {
+        return em.find(RecruitmentBoard.class, 1L);
     }
 
     private Place createTestPlace() {
@@ -93,7 +99,7 @@ class CommentTest {
     }
 
     private Comment createTestComment() {
-        RecruitmentBoard recruitmentBoard = createRecruitmentBoard();
+        RecruitmentBoard recruitmentBoard = findTestRecruitmentBoard();
         LocalDateTime now = LocalDateTime.of(2023, 4, 8, 16, 48);
         Member writer = new Member("test@email.com", "test");
         writer.updateProfileImage("test_url");
@@ -109,7 +115,7 @@ class CommentTest {
         when(writer.getId()).thenReturn(1L);
 
         SoftAssertions softly = new SoftAssertions();
-        RecruitmentBoard recruitmentBoard = createRecruitmentBoard();
+        RecruitmentBoard recruitmentBoard = findTestRecruitmentBoard();
         LocalDateTime createdTime = LocalDateTime.of(2023, 4, 8, 16, 48);
 
         String commentBodyValue = "안녕하세요.";
@@ -135,7 +141,7 @@ class CommentTest {
         Member writer = mock(Member.class);
         when(writer.getId()).thenReturn(1L);
 
-        RecruitmentBoard recruitmentBoard = createRecruitmentBoard();
+        RecruitmentBoard recruitmentBoard = findTestRecruitmentBoard();
         LocalDateTime createdTime = LocalDateTime.of(2023, 4, 8, 16, 48);
         String commentBodyValue = "안녕하세요.";
         Comment comment = Comment.createOnRecruitmentBoardWith(recruitmentBoard, commentBodyValue, writer, createdTime);

--- a/src/test/java/mokindang/jubging/project_backend/comment/domain/CommentTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/comment/domain/CommentTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -209,22 +208,5 @@ class CommentTest {
         for (int i = 0; i < countOfReplyComment; i++) {
             comment.addReplyComment(replyComment);
         }
-    }
-
-    @ParameterizedTest
-    @CsvSource(value = {"1, true", "2, false"})
-    @DisplayName("구인 게시글과 댓글의 작성자가 일치하는지 확인한다.")
-    void isWriterOfBoard(final Long memberId, final boolean expect) {
-        //given
-        RecruitmentBoard testRecruitmentBoard = findTestRecruitmentBoard();
-        Member member = mock(Member.class);
-        when(member.getId()).thenReturn(memberId);
-        Comment comment = Comment.createOnRecruitmentBoardWith(testRecruitmentBoard, "댓글 본문", member, LocalDateTime.now());
-
-        //when
-        boolean actual = comment.isSameWriterId(1L);
-
-        //then
-        assertThat(actual).isEqualTo(expect);
     }
 }

--- a/src/test/java/mokindang/jubging/project_backend/comment/domain/CommentTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/comment/domain/CommentTest.java
@@ -4,8 +4,6 @@ import mokindang.jubging.project_backend.certification_board.domain.Certificatio
 import mokindang.jubging.project_backend.comment.domain.vo.CommentBody;
 import mokindang.jubging.project_backend.member.domain.Member;
 import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
-import mokindang.jubging.project_backend.recruitment_board.domain.vo.place.Coordinate;
-import mokindang.jubging.project_backend.recruitment_board.domain.vo.place.Place;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -51,11 +49,6 @@ class CommentTest {
 
     private RecruitmentBoard findTestRecruitmentBoard() {
         return em.find(RecruitmentBoard.class, 1L);
-    }
-
-    private Place createTestPlace() {
-        Coordinate coordinate = new Coordinate(1.1, 1.2);
-        return new Place(coordinate, "서울시 동작구 상도동 1-1");
     }
 
     @Test

--- a/src/test/java/mokindang/jubging/project_backend/comment/domain/CommentTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/comment/domain/CommentTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -215,5 +216,22 @@ class CommentTest {
         for (int i = 0; i < countOfReplyComment; i++) {
             comment.addReplyComment(replyComment);
         }
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"1, true", "2, false"})
+    @DisplayName("구인 게시글과 댓글의 작성자가 일치하는지 확인한다.")
+    void isWriterOfBoard(final Long memberId, final boolean expect) {
+        //given
+        RecruitmentBoard testRecruitmentBoard = findTestRecruitmentBoard();
+        Member member = mock(Member.class);
+        when(member.getId()).thenReturn(memberId);
+        Comment comment = Comment.createOnRecruitmentBoardWith(testRecruitmentBoard, "댓글 본문", member, LocalDateTime.now());
+
+        //when
+        boolean actual = comment.isSameWriterId(1L);
+
+        //then
+        assertThat(actual).isEqualTo(expect);
     }
 }

--- a/src/test/java/mokindang/jubging/project_backend/comment/service/CommentServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/comment/service/CommentServiceTest.java
@@ -87,6 +87,7 @@ class CommentServiceTest {
         when(memberService.findByMemberId(anyLong())).thenReturn(member);
         RecruitmentBoard board = mock(RecruitmentBoard.class);
         when(board.isParticipatedIn(anyLong())).thenReturn(true);
+        when(board.isSameWriterId(anyLong())).thenReturn(true);
         when(recruitmentBoardService.findByIdWithOptimisticLock(anyLong())).thenReturn(board);
 
         //when
@@ -112,7 +113,10 @@ class CommentServiceTest {
     }
 
     private Comment createMockedComment(final Long commentId) {
+        Member writer = mock(Member.class);
+        when(writer.getId()).thenReturn(1L);
         Comment comment = mock(Comment.class);
+        when(comment.getWriter()).thenReturn(writer);
         when(comment.getId()).thenReturn(commentId);
         when(comment.getCommentBody()).thenReturn(new CommentBody("본문내용"));
         when(comment.isSameWriterId(any())).thenReturn(true);

--- a/src/test/java/mokindang/jubging/project_backend/comment/service/CommentServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/comment/service/CommentServiceTest.java
@@ -10,6 +10,7 @@ import mokindang.jubging.project_backend.comment.service.request.ReplyCommentCre
 import mokindang.jubging.project_backend.comment.service.response.CommentIdResponse;
 import mokindang.jubging.project_backend.comment.service.response.MultiCommentSelectionResponse;
 import mokindang.jubging.project_backend.member.domain.Member;
+import mokindang.jubging.project_backend.member.domain.vo.Region;
 import mokindang.jubging.project_backend.member.service.MemberService;
 import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
 import mokindang.jubging.project_backend.recruitment_board.service.RecruitmentBoardService;
@@ -80,8 +81,13 @@ class CommentServiceTest {
         ReplyComment mockedReplyComment = createMockedReplyComment();
         when(comment1.getReplyComments()).thenReturn(List.of(mockedReplyComment));
         Comment comment2 = createMockedComment(2L);
-
         when(commentRepository.findCommentsByRecruitmentBoardId(anyLong())).thenReturn(List.of(comment1, comment2));
+        Member member = mock(Member.class);
+        when(member.getRegion()).thenReturn(Region.from("동작구"));
+        when(memberService.findByMemberId(anyLong())).thenReturn(member);
+        RecruitmentBoard board = mock(RecruitmentBoard.class);
+        when(board.isParticipatedIn(anyLong())).thenReturn(true);
+        when(recruitmentBoardService.findByIdWithOptimisticLock(anyLong())).thenReturn(board);
 
         //when
         MultiCommentSelectionResponse multiCommentSelectionResponse = commentService.selectComments(1L, BoardType.RECRUITMENT_BOARD, 1L);

--- a/src/test/java/mokindang/jubging/project_backend/recruitment_board/domain/participation/ParticipationTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/recruitment_board/domain/participation/ParticipationTest.java
@@ -1,0 +1,35 @@
+package mokindang.jubging.project_backend.recruitment_board.domain.participation;
+
+import mokindang.jubging.project_backend.member.domain.Member;
+import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ParticipationTest {
+
+    @ParameterizedTest
+    @CsvSource(value = {"1, true", "2, false"})
+    @DisplayName("입력받은 회원의 id 가 참여에 있는 id 와 일치하면 true 를 반환하고 일치하지 않을 경우 false 를 반환한다.")
+    void isParticipatedIn(final Long memberId, final boolean expected) {
+        //given
+        RecruitmentBoard board = mock(RecruitmentBoard.class);
+        Member member = mock(Member.class);
+        when(member.getId()).thenReturn(1L);
+
+        Participation participation = new Participation(board, member);
+
+        //when
+        boolean actual = participation.isParticipatedIn(memberId);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/src/test/java/mokindang/jubging/project_backend/service/board/RecruitmentBoardServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/service/board/RecruitmentBoardServiceTest.java
@@ -5,7 +5,10 @@ import mokindang.jubging.project_backend.member.domain.vo.Region;
 import mokindang.jubging.project_backend.member.service.MemberService;
 import mokindang.jubging.project_backend.recruitment_board.domain.ActivityCategory;
 import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
-import mokindang.jubging.project_backend.recruitment_board.domain.vo.*;
+import mokindang.jubging.project_backend.recruitment_board.domain.vo.ContentBody;
+import mokindang.jubging.project_backend.recruitment_board.domain.vo.ParticipationCount;
+import mokindang.jubging.project_backend.recruitment_board.domain.vo.StartingDate;
+import mokindang.jubging.project_backend.recruitment_board.domain.vo.Title;
 import mokindang.jubging.project_backend.recruitment_board.domain.vo.place.Coordinate;
 import mokindang.jubging.project_backend.recruitment_board.domain.vo.place.Place;
 import mokindang.jubging.project_backend.recruitment_board.repository.RecruitmentBoardRepository;
@@ -22,8 +25,6 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -305,29 +306,6 @@ class RecruitmentBoardServiceTest {
         //then
         assertThat(multiBoardPlaceSelectionResponse.getBoardPlaceMarkerResponses()).hasSize(2);
         verify(boardRepository, times(1)).selectRecruitmentRegionBoardsCloseToDeadline(any(Region.class), any(Pageable.class));
-    }
-
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    @DisplayName("요청 회원의 지역과 해당 게시글의 지역이 같은 경우 true 를 그렇지 않은경우 false 를 반환다.")
-    void hasWritingCommentPermission(final boolean input) {
-        //given
-        Member member = mock(Member.class);
-        when(member.getRegion()).thenReturn(Region.from("성동구"));
-        when(memberService.findByMemberId(anyLong())).thenReturn(member);
-
-        RecruitmentBoard board = mock(RecruitmentBoard.class);
-        when(board.isSameRegion(any(Region.class))).thenReturn(input);
-        when(boardRepository.findByIdWithOptimisticLock(anyLong())).thenReturn(Optional.ofNullable(board));
-
-        Long memberId = 1L;
-        Long boardId = 1L;
-
-        //when
-        boolean actual = boardService.hasWritingCommentPermission(memberId, boardId);
-
-        //then
-        assertThat(actual).isEqualTo(input);
     }
 
     @Test


### PR DESCRIPTION
# Feature/#392/플로깅 참여 여부 확인 기능 구현

### 이슈 번호 : 392

## 변경 사항
-    플로깅 참여 여부 확인 기능 구현
  댓글 조회시 플로깅 참여 여부 확인 할 수 있도록 변경
    - 댓글 조회 시 댓글 작성자가 해당 게시글의 작성자인지 확인 할 수 있도록 변경함


## 그 외
- 테스트용 데이터 추가 및 댓글 CommentService 에서 각 게시글 마다 댓글 반환 DTO 생성하는 메서드를 분리함.
## 질문 사항
- 
