### PR TITLE
Refactor/#392/플로깅 구인 게시글 조회 값 추가

### DIFF
--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/RecruitmentBoardService.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/RecruitmentBoardService.java
@@ -52,7 +52,8 @@ public class RecruitmentBoardService {
 
     public RecruitmentBoardSelectionResponse select(final Long memberId, final Long boardId) {
         RecruitmentBoard recruitmentBoard = findByIdWithOptimisticLock(boardId);
-        return new RecruitmentBoardSelectionResponse(recruitmentBoard, recruitmentBoard.isSameWriterId(memberId));
+        Member member = memberService.findByMemberId(memberId);
+        return new RecruitmentBoardSelectionResponse(member, recruitmentBoard);
     }
 
     public RecruitmentBoard findByIdWithOptimisticLock(final Long boardId) {

--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/response/RecruitmentBoardSelectionResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/response/RecruitmentBoardSelectionResponse.java
@@ -2,6 +2,7 @@ package mokindang.jubging.project_backend.recruitment_board.service.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import mokindang.jubging.project_backend.member.domain.Member;
 import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
 
 import java.time.LocalDateTime;
@@ -45,8 +46,14 @@ public class RecruitmentBoardSelectionResponse {
     @Schema(description = "게시글 조회 회원이, 작성자인지에 대한 정보", allowableValues = {"true", "false"})
     private final boolean mine;
 
-    @Schema(description =  "만남 장소")
+    @Schema(description = "만남 장소")
     private final MeetingPlaceResponse meetingPlaceResponse;
+
+    @Schema(description = "게시글과 회원의 지역이 같은지 여부")
+    private final boolean sameRegion;
+
+    @Schema(description = "조회한 회원이 이미 참여 했는지 여부")
+    private final boolean participated;
 
     @Schema(description = "현재 모집 인원")
     private final int participationCount;
@@ -55,7 +62,7 @@ public class RecruitmentBoardSelectionResponse {
     private final int maxOfParticipationCount;
 
 
-    public RecruitmentBoardSelectionResponse(final RecruitmentBoard board, final boolean mine) {
+    public RecruitmentBoardSelectionResponse(final Member member, final RecruitmentBoard board) {
         this.boardId = board.getId();
         this.title = board.getTitle()
                 .getValue();
@@ -72,11 +79,13 @@ public class RecruitmentBoardSelectionResponse {
         this.onRecruitment = board.isOnRecruitment();
         this.firstFourLettersOfEmail = board.getFirstFourDigitsOfWriterEmail();
         this.writerProfileImageUrl = board.getWriterProfileImageUrl();
-        this.mine = mine;
+        this.mine = board.isSameWriterId(member.getId());
         this.meetingPlaceResponse = new MeetingPlaceResponse(board);
         this.participationCount = board.getParticipationCount()
                 .getCount();
         this.maxOfParticipationCount = board.getParticipationCount()
                 .getMax();
+        this.participated = board.isParticipatedIn(member.getId());
+        this.sameRegion = board.isSameRegion(member.getRegion());
     }
 }

--- a/src/test/java/mokindang/jubging/project_backend/service/board/RecruitmentBoardServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/service/board/RecruitmentBoardServiceTest.java
@@ -108,36 +108,20 @@ class RecruitmentBoardServiceTest {
     void selectBoardId() {
         //given
         SoftAssertions softly = new SoftAssertions();
-        RecruitmentBoard recruitmentBoard = mock(RecruitmentBoard.class);
-        when(recruitmentBoard.getId()).thenReturn(1L);
-        when(recruitmentBoard.getTitle()).thenReturn(new Title("제목입니다."));
-        when(recruitmentBoard.getWriterAlias()).thenReturn("글작성자");
-        when(recruitmentBoard.getWritingRegion()).thenReturn(Region.from("동작구"));
-        when(recruitmentBoard.getActivityCategory()).thenReturn(ActivityCategory.RUNNING);
-        when(recruitmentBoard.isOnRecruitment()).thenReturn(true);
-        LocalDate now = LocalDate.of(2023, 3, 10);
-        when(recruitmentBoard.getStartingDate()).thenReturn(new StartingDate(now, LocalDate.of(2023, 3, 11)));
-        when(recruitmentBoard.getFirstFourDigitsOfWriterEmail()).thenReturn("test");
-        when(recruitmentBoard.getWriterProfileImageUrl()).thenReturn("test_url");
-        when(recruitmentBoard.isSameWriterId(anyLong())).thenReturn(true);
-        when(recruitmentBoard.getContentBody()).thenReturn(new ContentBody("본문내용입니다."));
-        Coordinate coordinate = new Coordinate(1.1, 1.2);
-        when(recruitmentBoard.getMeetingPlace()).thenReturn(createTestPlace());
-        ParticipationCount participationCount = mock(ParticipationCount.class);
-        when(participationCount.getCount()).thenReturn(3);
-        when(participationCount.getMax()).thenReturn(8);
-        when(recruitmentBoard.getParticipationCount()).thenReturn(participationCount);
+        RecruitmentBoard recruitmentBoard = createMockedBoard();
         when(boardRepository.findByIdWithOptimisticLock(1L)).thenReturn(Optional.of(recruitmentBoard));
+        Member member = createMockedMember();
+        when(memberService.findByMemberId(1L)).thenReturn(member);
 
         //when
         RecruitmentBoardSelectionResponse actual = boardService.select(1L, 1L);
 
         //then
         softly.assertThat(actual.getBoardId()).isEqualTo(1L);
-        softly.assertThat(actual.getTitle()).isEqualTo("제목입니다.");
-        softly.assertThat(actual.getContentBody()).isEqualTo("본문내용입니다.");
-        softly.assertThat(actual.getWriterAlias()).isEqualTo("글작성자");
-        softly.assertThat(actual.getStartingDate()).isEqualTo("2023-03-11");
+        softly.assertThat(actual.getTitle()).isEqualTo("제목");
+        softly.assertThat(actual.getContentBody()).isEqualTo("본문내용");
+        softly.assertThat(actual.getWriterAlias()).isEqualTo("test");
+        softly.assertThat(actual.getStartingDate()).isEqualTo("2025-02-11");
         softly.assertThat(actual.getActivityCategory()).isEqualTo("달리기");
         softly.assertThat(actual.isOnRecruitment()).isEqualTo(true);
         softly.assertThat(actual.getWriterProfileImageUrl()).isEqualTo("test_url");
@@ -146,9 +130,37 @@ class RecruitmentBoardServiceTest {
         softly.assertThat(actual.getMeetingPlaceResponse().getLatitude()).isEqualTo(1.2);
         softly.assertThat(actual.getMeetingPlaceResponse().getMeetingAddress()).isEqualTo("서울시 동작구 상도동 1-1");
         softly.assertThat(actual.isMine()).isEqualTo(true);
-        softly.assertThat(actual.getParticipationCount()).isEqualTo(3);
+        softly.assertThat(actual.getParticipationCount()).isEqualTo(1);
         softly.assertThat(actual.getMaxOfParticipationCount()).isEqualTo(8);
         softly.assertAll();
+    }
+
+    private Member createMockedMember() {
+        Member member = mock(Member.class);
+        when(member.getId()).thenReturn(1L);
+        when(member.getRegion()).thenReturn(Region.from("동작구"));
+        return member;
+    }
+
+    private RecruitmentBoard createMockedBoard() {
+        LocalDate today = LocalDate.of(2023, 3, 14);
+        RecruitmentBoard recruitmentBoard = mock(RecruitmentBoard.class);
+        when(recruitmentBoard.getId()).thenReturn(1L);
+        when(recruitmentBoard.getTitle()).thenReturn(new Title("제목"));
+        when(recruitmentBoard.getContentBody()).thenReturn(new ContentBody("본문내용"));
+        when(recruitmentBoard.getWritingRegion()).thenReturn(Region.from("동작구"));
+        when(recruitmentBoard.getActivityCategory()).thenReturn(ActivityCategory.RUNNING);
+        when(recruitmentBoard.isOnRecruitment()).thenReturn(true);
+        when(recruitmentBoard.getCreatingDateTime()).thenReturn(LocalDateTime.of(2023, 11, 12, 0, 0, 0));
+        when(recruitmentBoard.getStartingDate()).thenReturn(new StartingDate(today, LocalDate.of(2025, 2, 11)));
+        when(recruitmentBoard.getWriterAlias()).thenReturn("test");
+        when(recruitmentBoard.getFirstFourDigitsOfWriterEmail()).thenReturn("test");
+        when(recruitmentBoard.getWriterProfileImageUrl()).thenReturn("test_url");
+        when(recruitmentBoard.getMeetingPlace()).thenReturn(createTestPlace());
+        when(recruitmentBoard.getParticipationCount()).thenReturn(ParticipationCount.createDefaultParticipationCount(8));
+        when(recruitmentBoard.isSameWriterId(1L)).thenReturn(true);
+        when(recruitmentBoard.isParticipatedIn(1L)).thenReturn(true);
+        return recruitmentBoard;
     }
 
     private Place createTestPlace() {

--- a/src/test/java/mokindang/jubging/project_backend/service/board/RecruitmentBoardServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/service/board/RecruitmentBoardServiceTest.java
@@ -132,6 +132,8 @@ class RecruitmentBoardServiceTest {
         softly.assertThat(actual.isMine()).isEqualTo(true);
         softly.assertThat(actual.getParticipationCount()).isEqualTo(1);
         softly.assertThat(actual.getMaxOfParticipationCount()).isEqualTo(8);
+        softly.assertThat(actual.isOnRecruitment()).isTrue();
+        softly.assertThat(actual.isSameRegion()).isTrue();
         softly.assertAll();
     }
 
@@ -160,6 +162,7 @@ class RecruitmentBoardServiceTest {
         when(recruitmentBoard.getParticipationCount()).thenReturn(ParticipationCount.createDefaultParticipationCount(8));
         when(recruitmentBoard.isSameWriterId(1L)).thenReturn(true);
         when(recruitmentBoard.isParticipatedIn(1L)).thenReturn(true);
+        when(recruitmentBoard.isSameRegion(Region.from("동작구"))).thenReturn(true);
         return recruitmentBoard;
     }
 

--- a/src/test/java/mokindang/jubging/project_backend/service/board/response/BoardSelectionResponseTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/service/board/response/BoardSelectionResponseTest.java
@@ -1,10 +1,14 @@
 package mokindang.jubging.project_backend.service.board.response;
 
+import mokindang.jubging.project_backend.member.domain.Member;
+import mokindang.jubging.project_backend.member.domain.vo.ProfileImage;
+import mokindang.jubging.project_backend.member.domain.vo.Region;
 import mokindang.jubging.project_backend.recruitment_board.domain.ActivityCategory;
 import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
-import mokindang.jubging.project_backend.recruitment_board.domain.vo.*;
-import mokindang.jubging.project_backend.member.domain.Member;
-import mokindang.jubging.project_backend.member.domain.vo.Region;
+import mokindang.jubging.project_backend.recruitment_board.domain.vo.ContentBody;
+import mokindang.jubging.project_backend.recruitment_board.domain.vo.ParticipationCount;
+import mokindang.jubging.project_backend.recruitment_board.domain.vo.StartingDate;
+import mokindang.jubging.project_backend.recruitment_board.domain.vo.Title;
 import mokindang.jubging.project_backend.recruitment_board.domain.vo.place.Coordinate;
 import mokindang.jubging.project_backend.recruitment_board.domain.vo.place.Place;
 import mokindang.jubging.project_backend.recruitment_board.service.response.RecruitmentBoardSelectionResponse;
@@ -22,19 +26,17 @@ import static org.mockito.Mockito.when;
 class BoardSelectionResponseTest {
 
     @Test
-    @DisplayName("게시글과 게시글의 작성자 여부를 입력받아 BoardSelectionResponse 를 생성한다.")
+    @DisplayName("게시글과  작성자를 입력받아 BoardSelectionResponse 를 생성한다.")
     void create() {
         //given
-        boolean mine = true;
+        Member member = createMockedMember();
         LocalDateTime now = LocalDateTime.of(2023, 11, 12, 0, 0, 0);
-        Member writer = new Member("test1@email.com", "test");
-        writer.updateRegion("동작구");
-        Coordinate coordinate = new Coordinate(1.1, 1.2);
+        Member writer = createMockedMember();
         RecruitmentBoard recruitmentBoard = new RecruitmentBoard(now, writer, LocalDate.of(2025, 2, 11), "달리기",
                 createTestPlace(), "제목", "본문내용", 8);
 
         //when, then
-        assertThatCode(() -> new RecruitmentBoardSelectionResponse(recruitmentBoard, mine)).doesNotThrowAnyException();
+        assertThatCode(() -> new RecruitmentBoardSelectionResponse(member, recruitmentBoard)).doesNotThrowAnyException();
     }
 
     private Place createTestPlace() {
@@ -48,8 +50,8 @@ class BoardSelectionResponseTest {
         //given
         SoftAssertions softly = new SoftAssertions();
         RecruitmentBoard recruitmentBoard = createMockedBoard();
-        boolean mine = true;
-        RecruitmentBoardSelectionResponse selectionResponse = new RecruitmentBoardSelectionResponse(recruitmentBoard, mine);
+        Member member = createMockedMember();
+        RecruitmentBoardSelectionResponse selectionResponse = new RecruitmentBoardSelectionResponse(member, recruitmentBoard);
 
         //when
         Long boardId = selectionResponse.getBoardId();
@@ -81,6 +83,14 @@ class BoardSelectionResponseTest {
         softly.assertAll();
     }
 
+    private Member createMockedMember() {
+        Member member = mock(Member.class);
+        when(member.getId()).thenReturn(1L);
+        when(member.getRegion()).thenReturn(Region.from("동작구"));
+        when(member.getProfileImage()).thenReturn(new ProfileImage("test_url"));
+        return member;
+    }
+
     private RecruitmentBoard createMockedBoard() {
         LocalDate today = LocalDate.of(2023, 3, 14);
         RecruitmentBoard recruitmentBoard = mock(RecruitmentBoard.class);
@@ -97,6 +107,8 @@ class BoardSelectionResponseTest {
         when(recruitmentBoard.getWriterProfileImageUrl()).thenReturn("test_url");
         when(recruitmentBoard.getMeetingPlace()).thenReturn(createTestPlace());
         when(recruitmentBoard.getParticipationCount()).thenReturn(ParticipationCount.createDefaultParticipationCount(8));
+        when(recruitmentBoard.isSameWriterId(1L)).thenReturn(true);
+        when(recruitmentBoard.isParticipatedIn(1L)).thenReturn(true);
         return recruitmentBoard;
     }
 }


### PR DESCRIPTION
# Refactor/#392/플로깅 구인 게시글 조회 값 추가

### 이슈 번호 : #392

## 변경 사항
-    게시글 조회 시 반환되는 `RecruitmentBoardSelectionResponse` 에 필드 추가
    - 추가 내용
        - 조회 회원이 게시글과 지역이 같은지 여부
        - 조회 회원이 이미 게시글에 참여하기 상태인지 여부
## 그 외
- 

## 질문 사항
- 
