### PR TITLE
Refactor/#409/구인 게시글 삭제 시 참여와의 데이터 무결성 깨짐 문제 해결

### DIFF
--- a/src/main/java/mokindang/jubging/project_backend/participation/domain/Participation.java
+++ b/src/main/java/mokindang/jubging/project_backend/participation/domain/Participation.java
@@ -1,4 +1,4 @@
-package mokindang.jubging.project_backend.recruitment_board.domain.participation;
+package mokindang.jubging.project_backend.participation.domain;
 
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/mokindang/jubging/project_backend/participation/domain/ParticipationId.java
+++ b/src/main/java/mokindang/jubging/project_backend/participation/domain/ParticipationId.java
@@ -1,4 +1,4 @@
-package mokindang.jubging.project_backend.recruitment_board.domain.participation;
+package mokindang.jubging.project_backend.participation.domain;
 
 import java.io.Serializable;
 import java.util.Objects;

--- a/src/main/java/mokindang/jubging/project_backend/participation/repository/ParticipationRepository.java
+++ b/src/main/java/mokindang/jubging/project_backend/participation/repository/ParticipationRepository.java
@@ -1,0 +1,14 @@
+package mokindang.jubging.project_backend.participation.repository;
+
+import mokindang.jubging.project_backend.participation.domain.Participation;
+import mokindang.jubging.project_backend.participation.domain.ParticipationId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface ParticipationRepository extends JpaRepository<Participation, ParticipationId> {
+
+
+    void deleteAllByRecruitmentBoardId(final Long boardId);
+}

--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/domain/RecruitmentBoard.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/domain/RecruitmentBoard.java
@@ -7,7 +7,7 @@ import mokindang.jubging.project_backend.comment.domain.Comment;
 import mokindang.jubging.project_backend.exception.custom.ForbiddenException;
 import mokindang.jubging.project_backend.member.domain.Member;
 import mokindang.jubging.project_backend.member.domain.vo.Region;
-import mokindang.jubging.project_backend.recruitment_board.domain.participation.Participation;
+import mokindang.jubging.project_backend.participation.domain.Participation;
 import mokindang.jubging.project_backend.recruitment_board.domain.vo.ContentBody;
 import mokindang.jubging.project_backend.recruitment_board.domain.vo.ParticipationCount;
 import mokindang.jubging.project_backend.recruitment_board.domain.vo.StartingDate;

--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/RecruitmentBoardService.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/RecruitmentBoardService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import mokindang.jubging.project_backend.member.domain.Member;
 import mokindang.jubging.project_backend.member.domain.vo.Region;
 import mokindang.jubging.project_backend.member.service.MemberService;
+import mokindang.jubging.project_backend.participation.repository.ParticipationRepository;
 import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
 import mokindang.jubging.project_backend.recruitment_board.domain.vo.place.Coordinate;
 import mokindang.jubging.project_backend.recruitment_board.domain.vo.place.Place;
@@ -36,6 +37,7 @@ public class RecruitmentBoardService {
 
     private final MemberService memberService;
     private final RecruitmentBoardRepository recruitmentBoardRepository;
+    private final ParticipationRepository participationRepository;
 
     @Transactional
     public RecruitmentBoardIdResponse write(final Long memberId, final RecruitmentBoardCreationRequest recruitmentBoardCreationRequest) {
@@ -81,6 +83,7 @@ public class RecruitmentBoardService {
         RecruitmentBoard recruitmentBoard = findByIdWithOptimisticLock(boardId);
         recruitmentBoard.validatePermission(memberId);
         recruitmentBoardRepository.delete(recruitmentBoard);
+        participationRepository.deleteAllByRecruitmentBoardId(boardId);
         return new RecruitmentBoardIdResponse(recruitmentBoard.getId());
     }
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -69,10 +69,6 @@ VALUES (2, '2023-3-10-11-0', '2023-4-10-11-0', '테스트 대댓글2', 1, 1);
 -- 참여상태
 INSERT INTO participation(member_id, recruitment_board_id)
 VALUES (1, 1);
-INSERT INTO participation(member_id, recruitment_board_id)
-VALUES (2, 1);
 
-INSERT INTO participation(member_id, recruitment_board_id)
-VALUES (3, 1);
 INSERT INTO participation(member_id, recruitment_board_id)
 VALUES (2, 2);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -66,9 +66,13 @@ VALUES (1, '2023-3-10-11-0', '2023-3-10-11-0', '테스트 대댓글1', 1, 1);
 INSERT INTO reply_comment (reply_comment_id, created_date_time, last_modified_date_time, body, comment_id, member_id)
 VALUES (2, '2023-3-10-11-0', '2023-4-10-11-0', '테스트 대댓글2', 1, 1);
 
--- 참여 2번 게시글에 1번 유저가 참여한 상태
+-- 참여상태
 INSERT INTO participation(member_id, recruitment_board_id)
 VALUES (1, 1);
+INSERT INTO participation(member_id, recruitment_board_id)
+VALUES (2, 1);
 
+INSERT INTO participation(member_id, recruitment_board_id)
+VALUES (3, 1);
 INSERT INTO participation(member_id, recruitment_board_id)
 VALUES (2, 2);

--- a/src/test/java/mokindang/jubging/project_backend/recruitment_board/domain/participation/ParticipationTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/recruitment_board/domain/participation/ParticipationTest.java
@@ -1,6 +1,7 @@
 package mokindang.jubging.project_backend.recruitment_board.domain.participation;
 
 import mokindang.jubging.project_backend.member.domain.Member;
+import mokindang.jubging.project_backend.participation.domain.Participation;
 import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/mokindang/jubging/project_backend/recruitment_board/service/RecruitmentBoardServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/recruitment_board/service/RecruitmentBoardServiceTest.java
@@ -3,6 +3,7 @@ package mokindang.jubging.project_backend.recruitment_board.service;
 import mokindang.jubging.project_backend.member.domain.Member;
 import mokindang.jubging.project_backend.member.domain.vo.Region;
 import mokindang.jubging.project_backend.member.service.MemberService;
+import mokindang.jubging.project_backend.participation.repository.ParticipationRepository;
 import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
 import mokindang.jubging.project_backend.recruitment_board.domain.vo.place.Coordinate;
 import mokindang.jubging.project_backend.recruitment_board.domain.vo.place.Place;
@@ -45,6 +46,9 @@ class RecruitmentBoardServiceTest {
 
     @Mock
     private RecruitmentBoardRepository boardRepository;
+
+    @Mock
+    private ParticipationRepository participationRepository;
 
     @InjectMocks
     private RecruitmentBoardService boardService;

--- a/src/test/java/mokindang/jubging/project_backend/recruitment_board/service/RecruitmentBoardServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/recruitment_board/service/RecruitmentBoardServiceTest.java
@@ -151,7 +151,8 @@ class RecruitmentBoardServiceTest {
 
         //then
         assertThat(deleteBoardIdResponse.getBoardId()).isEqualTo(boardId);
-        verify(boardRepository, times(1)).delete(any());
+        verify(boardRepository, times(1)).delete(any(RecruitmentBoard.class));
+        verify(participationRepository, times(1)).deleteAllByRecruitmentBoardId(anyLong());
     }
 
     @Test


### PR DESCRIPTION
# Refactor/#409/구인 게시글 삭제 시 참여와의 데이터 무결성 깨짐 문제 해결

### 이슈 번호 : #409 

## 변경 사항
-    participation 도메인 분리
- 게시글 삭제 시, 해당 게시글 id 를 키로 갖고 있는 participation 삭제하도록 함
## 그 외
- 

## 질문 사항
- 
