### PR TITLE
Refactor/#413/요약 게시글 조회 api 리팩토링

### DIFF
--- a/src/main/java/mokindang/jubging/project_backend/comment/repository/CommentRepository.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/repository/CommentRepository.java
@@ -1,12 +1,21 @@
 package mokindang.jubging.project_backend.comment.repository;
 
 import mokindang.jubging.project_backend.comment.domain.Comment;
+import mokindang.jubging.project_backend.comment.repository.projectionDto.CommentCountResponse;
 import mokindang.jubging.project_backend.comment.service.BoardType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findCommentByBoardTypeAndBoardId(final BoardType boardType, final Long boardId);
+
+    @Query("SELECT COUNT(DISTINCT c.id) + COUNT(rc.id) AS commentCount " +
+            "FROM Comment c " +
+            "LEFT JOIN c.replyComments rc ON c.id = rc.comment.id " +
+            "where c.boardId IN :boardIds AND c.boardType =:boardType " +
+            "GROUP BY c.boardId")
+    List<CommentCountResponse> countALLCommentByBoardIds(final List<Long> boardIds, final BoardType boardType);
 }

--- a/src/main/java/mokindang/jubging/project_backend/comment/repository/projectionDto/CommentCountResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/repository/projectionDto/CommentCountResponse.java
@@ -1,0 +1,6 @@
+package mokindang.jubging.project_backend.comment.repository.projectionDto;
+
+public interface CommentCountResponse {
+
+    Long getCommentCount();
+}

--- a/src/main/java/mokindang/jubging/project_backend/comment/service/strategy/RecruitmentBoardCommentsSelectionStrategy.java
+++ b/src/main/java/mokindang/jubging/project_backend/comment/service/strategy/RecruitmentBoardCommentsSelectionStrategy.java
@@ -25,7 +25,7 @@ public class RecruitmentBoardCommentsSelectionStrategy implements CommentsSelect
     private final RecruitmentBoardService recruitmentBoardService;
 
     @Override
-    public MultiCommentSelectionResponse selectComments(Long boardId, Long memberId) {
+    public MultiCommentSelectionResponse selectComments(final Long boardId, final Long memberId) {
         List<Comment> commentsByRecruitmentBoard = commentRepository.findCommentByBoardTypeAndBoardId(BOARD_TYPE, boardId);
         Member member = memberService.findByMemberId(memberId);
         RecruitmentBoard board = recruitmentBoardService.findByIdWithOptimisticLock(boardId);

--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/RecruitmentBoardService.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/RecruitmentBoardService.java
@@ -1,6 +1,9 @@
 package mokindang.jubging.project_backend.recruitment_board.service;
 
 import lombok.RequiredArgsConstructor;
+import mokindang.jubging.project_backend.comment.repository.CommentRepository;
+import mokindang.jubging.project_backend.comment.repository.projectionDto.CommentCountResponse;
+import mokindang.jubging.project_backend.comment.service.BoardType;
 import mokindang.jubging.project_backend.member.domain.Member;
 import mokindang.jubging.project_backend.member.domain.vo.Region;
 import mokindang.jubging.project_backend.member.service.MemberService;
@@ -13,7 +16,7 @@ import mokindang.jubging.project_backend.recruitment_board.service.request.Board
 import mokindang.jubging.project_backend.recruitment_board.service.request.MeetingPlaceCreationRequest;
 import mokindang.jubging.project_backend.recruitment_board.service.request.MeetingPlaceModificationRequest;
 import mokindang.jubging.project_backend.recruitment_board.service.request.RecruitmentBoardCreationRequest;
-import mokindang.jubging.project_backend.recruitment_board.service.response.*;
+import mokindang.jubging.project_backend.recruitment_board.service.response.RecruitmentBoardIdResponse;
 import mokindang.jubging.project_backend.recruitment_board.service.response.board.MultiBoardSelectionResponse;
 import mokindang.jubging.project_backend.recruitment_board.service.response.board.RecruitmentBoardSelectionResponse;
 import mokindang.jubging.project_backend.recruitment_board.service.response.board.SummaryBoardResponse;
@@ -29,15 +32,19 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class RecruitmentBoardService {
 
+    private static final int FIRST_INDEX = 0;
+
     private final MemberService memberService;
     private final RecruitmentBoardRepository recruitmentBoardRepository;
     private final ParticipationRepository participationRepository;
+    private final CommentRepository commentRepository;
 
     @Transactional
     public RecruitmentBoardIdResponse write(final Long memberId, final RecruitmentBoardCreationRequest recruitmentBoardCreationRequest) {
@@ -58,7 +65,6 @@ public class RecruitmentBoardService {
         return new Place(meetingSpot, meetingAddress);
     }
 
-
     public RecruitmentBoardSelectionResponse select(final Long memberId, final Long boardId) {
         RecruitmentBoard recruitmentBoard = findByIdWithOptimisticLock(boardId);
         Member member = memberService.findByMemberId(memberId);
@@ -71,11 +77,23 @@ public class RecruitmentBoardService {
     }
 
     public MultiBoardSelectionResponse selectAllBoards(final Pageable pageable) {
-        Slice<RecruitmentBoard> recruitmentBoards = recruitmentBoardRepository.selectBoards(pageable);
-        List<SummaryBoardResponse> summaryRecruitmentBoards = recruitmentBoards.stream()
-                .map(SummaryBoardResponse::new)
+        Slice<RecruitmentBoard> boards = recruitmentBoardRepository.selectBoards(pageable);
+        List<SummaryBoardResponse> summaryRecruitmentBoards = convertToSummaryBoardResponses(boards.getContent());
+        return new MultiBoardSelectionResponse(summaryRecruitmentBoards, boards.hasNext());
+    }
+
+    private List<SummaryBoardResponse> convertToSummaryBoardResponses(final List<RecruitmentBoard> boards) {
+        List<CommentCountResponse> commentCountResponses = getCommentCountResponse(boards);
+        return IntStream.range(FIRST_INDEX, boards.size())
+                .mapToObj(index -> new SummaryBoardResponse(boards.get(index), commentCountResponses.get(index).getCommentCount())
+                ).collect(Collectors.toUnmodifiableList());
+    }
+
+    private List<CommentCountResponse> getCommentCountResponse(final List<RecruitmentBoard> boards) {
+        List<Long> boardIds = boards.stream()
+                .map(board -> board.getId())
                 .collect(Collectors.toUnmodifiableList());
-        return new MultiBoardSelectionResponse(summaryRecruitmentBoards, recruitmentBoards.hasNext());
+        return commentRepository.countALLCommentByBoardIds(boardIds, BoardType.RECRUITMENT_BOARD);
     }
 
     @Transactional
@@ -114,10 +132,8 @@ public class RecruitmentBoardService {
         Member loggedInMember = memberService.findByMemberId(memberId);
         Region targetRegion = loggedInMember.getRegion();
         Slice<RecruitmentBoard> boards = recruitmentBoardRepository.selectRegionBoards(targetRegion, pageable);
-        List<SummaryBoardResponse> summaryBoards = boards.stream()
-                .map(SummaryBoardResponse::new)
-                .collect(Collectors.toUnmodifiableList());
-        return new MultiBoardSelectionResponse(summaryBoards, boards.hasNext());
+        List<SummaryBoardResponse> summaryBoardResponses = convertToSummaryBoardResponses(boards.getContent());
+        return new MultiBoardSelectionResponse(summaryBoardResponses, boards.hasNext());
     }
 
     public MultiBoardPlaceSelectionResponse selectRegionBoardsCloseToDeadline(final Long memberId, final Pageable pageable) {

--- a/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/response/board/SummaryBoardResponse.java
+++ b/src/main/java/mokindang/jubging/project_backend/recruitment_board/service/response/board/SummaryBoardResponse.java
@@ -47,7 +47,7 @@ public class SummaryBoardResponse {
     @Schema(description = "게시글에 참여한 회원의 수")
     private final int countOfParticipation;
 
-    public SummaryBoardResponse(final RecruitmentBoard recruitmentBoard) {
+    public SummaryBoardResponse(final RecruitmentBoard recruitmentBoard, final Long countOfCommentAndReplyComment) {
         this.boardId = recruitmentBoard.getId();
         this.title = recruitmentBoard.getTitle()
                 .getValue();
@@ -63,7 +63,7 @@ public class SummaryBoardResponse {
                 .getValue();
         this.onRecruitment = recruitmentBoard.isOnRecruitment();
         this.firstFourLettersOfEmail = recruitmentBoard.getFirstFourDigitsOfWriterEmail();
-        this.countOfCommentAndReplyComment = recruitmentBoard.countCommentAndReplyComment();
+        this.countOfCommentAndReplyComment = countOfCommentAndReplyComment;
         this.countOfMaxParticipation = recruitmentBoard.getParticipationCount().getMax();
         this.countOfParticipation = recruitmentBoard.getParticipationCount().getCount();
     }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -51,16 +51,13 @@ VALUES (1, '2023-3-9-12-0', '2023-3-9-12-0', '인증제목1', '인증본문1');
 
 -- 댓글
 INSERT INTO comment (body, created_date_time, last_modified_date_time, board_type, board_id, member_id)
-VALUES ('테스트 댓글', '2023-3-10-11-0', '2023-3-10-11-0', 'recruitment-board', 1, 1);
+VALUES ('테스트 댓글', '2023-3-10-11-0', '2023-3-10-11-0', 'RECRUITMENT_BOARD', 1, 1);
 
 INSERT INTO comment (body, created_date_time, last_modified_date_time, board_type, board_id, member_id)
-VALUES ('테스트 댓글', '2023-3-10-11-0', '2023-3-10-11-0', 'recruitment-board', 1, 1);
+VALUES ('테스트 댓글', '2023-3-10-11-0', '2023-3-10-11-0', 'RECRUITMENT_BOARD', 1, 1);
 
 INSERT INTO comment (body, created_date_time, last_modified_date_time, board_type, board_id, member_id)
-VALUES ('테스트 댓글', '2023-3-10-11-0', '2023-3-10-11-0', 'recruitment-board', 2, 1);
-
-INSERT INTO comment (body, created_date_time, last_modified_date_time, board_type, board_id, member_id)
-VALUES ('테스트 댓글', '2023-3-10-11-0', '2023-3-10-11-0', 'recruitment-board', 3, 1);
+VALUES ('테스트 댓글', '2023-3-10-11-0', '2023-3-10-11-0', 'RECRUITMENT_BOARD', 2, 1);
 
 
 
@@ -68,11 +65,11 @@ VALUES ('테스트 댓글', '2023-3-10-11-0', '2023-3-10-11-0', 'recruitment-boa
 INSERT INTO reply_comment (reply_comment_id, created_date_time, last_modified_date_time, body, comment_id, member_id)
 VALUES (1, '2023-3-10-11-0', '2023-3-10-11-0', '테스트 대댓글1', 1, 1);
 
-INSERT INTO reply_comment (reply_comment_id, created_date_time, last_modified_date_time, body, comment_id, member_id)
-VALUES (2, '2023-3-10-11-0', '2023-4-10-11-0', '테스트 대댓글2', 1, 1);
+# INSERT INTO reply_comment (reply_comment_id, created_date_time, last_modified_date_time, body, comment_id, member_id)
+# VALUES (2, '2023-3-10-11-0', '2023-4-10-11-0', '테스트 대댓글2', 1, 1);
 
-INSERT INTO reply_comment (reply_comment_id, created_date_time, last_modified_date_time, body, comment_id, member_id)
-VALUES (3, '2023-3-10-11-0', '2023-3-10-11-0', '테스트 대댓글1', 2, 1);
+# INSERT INTO reply_comment (reply_comment_id, created_date_time, last_modified_date_time, body, comment_id, member_id)
+# VALUES (3, '2023-3-10-11-0', '2023-3-10-11-0', '테스트 대댓글1', 2, 1);
 
 -- 참여상태
 INSERT INTO participation(member_id, recruitment_board_id)

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -56,6 +56,13 @@ VALUES ('테스트 댓글', '2023-3-10-11-0', '2023-3-10-11-0', 'recruitment-boa
 INSERT INTO comment (body, created_date_time, last_modified_date_time, board_type, board_id, member_id)
 VALUES ('테스트 댓글', '2023-3-10-11-0', '2023-3-10-11-0', 'recruitment-board', 1, 1);
 
+INSERT INTO comment (body, created_date_time, last_modified_date_time, board_type, board_id, member_id)
+VALUES ('테스트 댓글', '2023-3-10-11-0', '2023-3-10-11-0', 'recruitment-board', 2, 1);
+
+INSERT INTO comment (body, created_date_time, last_modified_date_time, board_type, board_id, member_id)
+VALUES ('테스트 댓글', '2023-3-10-11-0', '2023-3-10-11-0', 'recruitment-board', 3, 1);
+
+
 
 -- 대댓글
 INSERT INTO reply_comment (reply_comment_id, created_date_time, last_modified_date_time, body, comment_id, member_id)
@@ -63,6 +70,9 @@ VALUES (1, '2023-3-10-11-0', '2023-3-10-11-0', '테스트 대댓글1', 1, 1);
 
 INSERT INTO reply_comment (reply_comment_id, created_date_time, last_modified_date_time, body, comment_id, member_id)
 VALUES (2, '2023-3-10-11-0', '2023-4-10-11-0', '테스트 대댓글2', 1, 1);
+
+INSERT INTO reply_comment (reply_comment_id, created_date_time, last_modified_date_time, body, comment_id, member_id)
+VALUES (3, '2023-3-10-11-0', '2023-3-10-11-0', '테스트 대댓글1', 2, 1);
 
 -- 참여상태
 INSERT INTO participation(member_id, recruitment_board_id)

--- a/src/test/java/mokindang/jubging/project_backend/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/comment/repository/CommentRepositoryTest.java
@@ -1,0 +1,103 @@
+package mokindang.jubging.project_backend.comment.repository;
+
+import mokindang.jubging.project_backend.comment.domain.Comment;
+import mokindang.jubging.project_backend.comment.domain.ReplyComment;
+import mokindang.jubging.project_backend.comment.repository.projectionDto.CommentCountResponse;
+import mokindang.jubging.project_backend.comment.service.BoardType;
+import mokindang.jubging.project_backend.member.domain.Member;
+import mokindang.jubging.project_backend.member.repository.MemberRepository;
+import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
+import mokindang.jubging.project_backend.recruitment_board.domain.vo.place.Coordinate;
+import mokindang.jubging.project_backend.recruitment_board.domain.vo.place.Place;
+import mokindang.jubging.project_backend.recruitment_board.repository.RecruitmentBoardRepository;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.annotation.Rollback;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class CommentRepositoryTest {
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private ReplyCommentRepository replyCommentRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private RecruitmentBoardRepository recruitmentBoardRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Rollback
+    @Test
+    @DisplayName("boardId 리스트와 댓글 타입을 입력 받아, 각각의 댓글과 대댓글의 갯수를 반환한다.")
+    void countCommentsByBoardId() {
+        //given
+        SoftAssertions softly = new SoftAssertions();
+        LocalDateTime now = LocalDateTime.of(2023, 3, 27, 11, 11, 11);
+        Member writer = createMember();
+        memberRepository.save(writer);
+
+        RecruitmentBoard boardA = createRecruitmentBoard(writer);
+        RecruitmentBoard boardB = createRecruitmentBoard(writer);
+        RecruitmentBoard savedBoardA = recruitmentBoardRepository.save(boardA);
+        RecruitmentBoard savedBoardB = recruitmentBoardRepository.save(boardB);
+
+        setCommentAndReplyComment(savedBoardA, writer, now, savedBoardB);
+        entityManager.flush();
+
+        //when
+        List<CommentCountResponse> commentCountResponses = commentRepository.countALLCommentByBoardIds(List.of(savedBoardA.getId(), savedBoardB.getId()), BoardType.RECRUITMENT_BOARD);
+
+        //then
+        entityManager.clear();
+        assertThat(commentCountResponses.get(0).getCommentCount()).isEqualTo(3);
+        assertThat(commentCountResponses.get(1).getCommentCount()).isEqualTo(1);
+    }
+
+    private static Member createMember() {
+        Member member = new Member("test@mail.com", "test");
+        member.updateRegion("동작구");
+        return member;
+    }
+
+    private RecruitmentBoard createRecruitmentBoard(final Member writer) {
+        LocalDateTime now = LocalDateTime.of(2023, 3, 25, 1, 1);
+        RecruitmentBoard recruitingRecruitmentBoardWithPastStartingDate = new RecruitmentBoard(now, writer, LocalDate.of(2023, 3, 27), "달리기", createTestPlace(), "제목", "본문", 8);
+        return recruitingRecruitmentBoardWithPastStartingDate;
+    }
+
+    private Place createTestPlace() {
+        Coordinate coordinate = new Coordinate(1.1, 1.2);
+        return new Place(coordinate, "서울시 동작구 상도동 1-1");
+    }
+
+    private void setCommentAndReplyComment(RecruitmentBoard savedBoardA, Member writer, LocalDateTime now, RecruitmentBoard savedBoardB) {
+        Comment commentAOnBoardA = new Comment(savedBoardA.getId(), BoardType.RECRUITMENT_BOARD, "a", writer, now);
+        Comment commentBOnBoardA = new Comment(savedBoardA.getId(), BoardType.RECRUITMENT_BOARD, "b", writer, now);
+        Comment commentCOnBoardB = new Comment(savedBoardB.getId(), BoardType.RECRUITMENT_BOARD, "c", writer, now);
+        commentRepository.save(commentAOnBoardA);
+        commentRepository.save(commentBOnBoardA);
+        commentRepository.save(commentCOnBoardB);
+
+        ReplyComment replyCommentAOnCommentAOnBoardA = new ReplyComment(commentAOnBoardA, "aa", writer, now);
+        replyCommentRepository.save(replyCommentAOnCommentAOnBoardA);
+    }
+}

--- a/src/test/java/mokindang/jubging/project_backend/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/member/repository/MemberRepositoryTest.java
@@ -1,7 +1,6 @@
 package mokindang.jubging.project_backend.member.repository;
 
 import mokindang.jubging.project_backend.member.domain.Member;
-import mokindang.jubging.project_backend.member.repository.MemberRepository;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,7 +11,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -52,22 +51,6 @@ class MemberRepositoryTest {
 
         //then
         assertThat(findMember).isEqualTo(saveMember);
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 ID가 주어지면 아무것도 반환하지 않는다.")
-    public void findByIdError() {
-        //given
-        Long testId = 10L;
-        Member testMember = new Member("koho1047@naver.com", "고민호");
-        memberRepository.save(testMember);
-
-        //when
-        Optional<Member> findMember = memberRepository.findById(testId);
-
-        //then
-        assertThat(findMember).isEmpty();
-
     }
 
     @Test

--- a/src/test/java/mokindang/jubging/project_backend/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/member/repository/MemberRepositoryTest.java
@@ -22,7 +22,7 @@ class MemberRepositoryTest {
 
     @Test
     @DisplayName("멤버의 email 과 alias를 데이터베이스에 저장한다.")
-    public void save(){
+    public void save() {
         //given
         SoftAssertions softly = new SoftAssertions();
         Member testMember = new Member("koho1047@naver.com", "고민호");
@@ -47,7 +47,7 @@ class MemberRepositoryTest {
 
         //when
         Member findMember = memberRepository.findById(saveMember.getId())
-                                            .get();
+                .get();
 
         //then
         assertThat(findMember).isEqualTo(saveMember);
@@ -62,7 +62,7 @@ class MemberRepositoryTest {
 
         //when
         Member findMember = memberRepository.findByEmail(saveMember.getEmail())
-                                            .get();
+                .get();
 
         //then
         assertThat(findMember).isEqualTo(saveMember);
@@ -84,7 +84,7 @@ class MemberRepositoryTest {
 
     @Test
     @DisplayName("모든 멤버를 반환한다.")
-    public void findAll(){
+    public void findAll() {
         //given
         Member member1 = new Member("dog123@naver.com", "철수");
         Member member2 = new Member("cat456@naver.com", "영희");
@@ -95,6 +95,6 @@ class MemberRepositoryTest {
         List<Member> members = memberRepository.findAll();
 
         //then
-        assertThat(members).contains(saveMember1,saveMember2);
+        assertThat(members).contains(saveMember1, saveMember2);
     }
 }

--- a/src/test/java/mokindang/jubging/project_backend/recruitment_board/controller/RecruitmentBoardControllerTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/recruitment_board/controller/RecruitmentBoardControllerTest.java
@@ -2,25 +2,13 @@ package mokindang.jubging.project_backend.recruitment_board.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import mokindang.jubging.project_backend.exception.custom.ForbiddenException;
-import mokindang.jubging.project_backend.member.domain.Member;
-import mokindang.jubging.project_backend.member.domain.vo.ProfileImage;
-import mokindang.jubging.project_backend.member.domain.vo.Region;
-import mokindang.jubging.project_backend.recruitment_board.controller.RecruitmentBoardController;
-import mokindang.jubging.project_backend.recruitment_board.domain.ActivityCategory;
-import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
-import mokindang.jubging.project_backend.recruitment_board.domain.vo.ContentBody;
-import mokindang.jubging.project_backend.recruitment_board.domain.vo.ParticipationCount;
-import mokindang.jubging.project_backend.recruitment_board.domain.vo.StartingDate;
-import mokindang.jubging.project_backend.recruitment_board.domain.vo.Title;
-import mokindang.jubging.project_backend.recruitment_board.domain.vo.place.Coordinate;
-import mokindang.jubging.project_backend.recruitment_board.domain.vo.place.Place;
 import mokindang.jubging.project_backend.recruitment_board.service.RecruitmentBoardService;
 import mokindang.jubging.project_backend.recruitment_board.service.facade.OptimisticLockRecruitmentBoardResolver;
 import mokindang.jubging.project_backend.recruitment_board.service.request.BoardModificationRequest;
 import mokindang.jubging.project_backend.recruitment_board.service.request.MeetingPlaceCreationRequest;
 import mokindang.jubging.project_backend.recruitment_board.service.request.MeetingPlaceModificationRequest;
 import mokindang.jubging.project_backend.recruitment_board.service.request.RecruitmentBoardCreationRequest;
-import mokindang.jubging.project_backend.recruitment_board.service.response.*;
+import mokindang.jubging.project_backend.recruitment_board.service.response.RecruitmentBoardIdResponse;
 import mokindang.jubging.project_backend.recruitment_board.service.response.board.MultiBoardSelectionResponse;
 import mokindang.jubging.project_backend.recruitment_board.service.response.board.RecruitmentBoardSelectionResponse;
 import mokindang.jubging.project_backend.recruitment_board.service.response.board.SummaryBoardResponse;
@@ -39,14 +27,14 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static mokindang.jubging.project_backend.member.MockedMemberFactory.createMockedMember;
 import static mokindang.jubging.project_backend.recruitment_board.service.MockedRecruitmentBoardFactory.createMockedRecruitmentBoard;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -399,8 +387,8 @@ class RecruitmentBoardControllerTest {
     @DisplayName("특정 지역에 해당하는 구인 게시글 조회 시, HTTP 200 코드와 함께 요청 회원 지역에 해당하는 게시글 리스트를 반환한다.")
     void selectRegionBoards() throws Exception {
         //given
-        List<SummaryBoardResponse> summaryBoardResponses = List.of(new SummaryBoardResponse(createMockedRecruitmentBoard(1L)),
-                new SummaryBoardResponse(createMockedRecruitmentBoard(1L)));
+        List<SummaryBoardResponse> summaryBoardResponses = List.of(new SummaryBoardResponse(createMockedRecruitmentBoard(1L), 1L),
+                new SummaryBoardResponse(createMockedRecruitmentBoard(1L),0L));
         when(boardService.selectRegionBoards(anyLong(), any(Pageable.class)))
                 .thenReturn(new MultiBoardSelectionResponse(summaryBoardResponses, false));
 

--- a/src/test/java/mokindang/jubging/project_backend/recruitment_board/service/MockedRecruitmentBoardFactory.java
+++ b/src/test/java/mokindang/jubging/project_backend/recruitment_board/service/MockedRecruitmentBoardFactory.java
@@ -43,4 +43,21 @@ public class MockedRecruitmentBoardFactory {
         Coordinate coordinate = new Coordinate(1.1, 1.2);
         return new Place(coordinate, "서울시 동작구 상도동 1-1");
     }
+
+    public static RecruitmentBoard createMockedSummaryBoard(final Long boardId) {
+        LocalDate today = LocalDate.of(2023, 3, 14);
+        RecruitmentBoard recruitmentBoard = mock(RecruitmentBoard.class);
+        when(recruitmentBoard.getId()).thenReturn(boardId);
+        when(recruitmentBoard.getTitle()).thenReturn(new Title("제목"));
+        when(recruitmentBoard.getContentBody()).thenReturn(new ContentBody("본문내용"));
+        when(recruitmentBoard.getWritingRegion()).thenReturn(Region.from("동작구"));
+        when(recruitmentBoard.isOnRecruitment()).thenReturn(true);
+        when(recruitmentBoard.getStartingDate()).thenReturn(new StartingDate(today, LocalDate.of(2025, 2, 11)));
+        when(recruitmentBoard.getWriterAlias()).thenReturn("test");
+        when(recruitmentBoard.getFirstFourDigitsOfWriterEmail()).thenReturn("test");
+        when(recruitmentBoard.getWriterProfileImageUrl()).thenReturn("test_url");
+        when(recruitmentBoard.getActivityCategory()).thenReturn(ActivityCategory.WALK);
+        when(recruitmentBoard.getParticipationCount()).thenReturn(ParticipationCount.createDefaultParticipationCount(8));
+        return recruitmentBoard;
+    }
 }

--- a/src/test/java/mokindang/jubging/project_backend/recruitment_board/service/RecruitmentBoardServiceTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/recruitment_board/service/RecruitmentBoardServiceTest.java
@@ -1,5 +1,7 @@
 package mokindang.jubging.project_backend.recruitment_board.service;
 
+import mokindang.jubging.project_backend.comment.repository.CommentRepository;
+import mokindang.jubging.project_backend.comment.service.BoardType;
 import mokindang.jubging.project_backend.member.domain.Member;
 import mokindang.jubging.project_backend.member.domain.vo.Region;
 import mokindang.jubging.project_backend.member.service.MemberService;
@@ -49,6 +51,9 @@ class RecruitmentBoardServiceTest {
 
     @Mock
     private ParticipationRepository participationRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
 
     @InjectMocks
     private RecruitmentBoardService boardService;
@@ -234,10 +239,8 @@ class RecruitmentBoardServiceTest {
         LocalDateTime now = LocalDateTime.of(2023, 3, 25, 1, 1);
         Member dongJackMember = new Member("test@mail.com", "동작이");
         dongJackMember.updateRegion("동작구");
-        RecruitmentBoard dongJackBoard1 = new RecruitmentBoard(now.plusDays(1), dongJackMember,
-                LocalDate.of(2023, 3, 27), "달리기", createTestPlace(), "제목1", "본문1", 8);
-        RecruitmentBoard dongJackBoard2 = new RecruitmentBoard(now, dongJackMember,
-                LocalDate.of(2023, 3, 27), "산책", createTestPlace(), "제목2", "본문2", 8);
+        RecruitmentBoard dongJackBoard1 = MockedRecruitmentBoardFactory.createMockedSummaryBoard(1L);
+        RecruitmentBoard dongJackBoard2 = MockedRecruitmentBoardFactory.createMockedSummaryBoard(2L);
         Slice<RecruitmentBoard> slice = new SliceImpl<>(List.of(dongJackBoard1, dongJackBoard2));
 
         Member member = mock(Member.class);
@@ -245,7 +248,7 @@ class RecruitmentBoardServiceTest {
         when(memberService.findByMemberId(1L)).thenReturn(member);
         when(boardRepository.selectRegionBoards(any(Region.class), any(Pageable.class)))
                 .thenReturn(slice);
-
+        when(commentRepository.countALLCommentByBoardIds(any(), any(BoardType.class))).thenReturn(List.of(() -> 1L, () -> 2L));
         Long memberId = 1L;
         Pageable pageable = PageRequest.of(0, 2);
 
@@ -256,6 +259,7 @@ class RecruitmentBoardServiceTest {
         assertThat(multiBoardSelectionResponse.getBoards()).hasSize(2);
         verify(boardRepository, times(1)).selectRegionBoards(any(Region.class), any(Pageable.class));
     }
+
 
     private static Place createTestPlace() {
         Coordinate coordinate = new Coordinate(1.1, 1.2);

--- a/src/test/java/mokindang/jubging/project_backend/recruitment_board/service/response/SummaryBoardResponseTest.java
+++ b/src/test/java/mokindang/jubging/project_backend/recruitment_board/service/response/SummaryBoardResponseTest.java
@@ -4,7 +4,10 @@ import mokindang.jubging.project_backend.member.domain.Member;
 import mokindang.jubging.project_backend.member.domain.vo.Region;
 import mokindang.jubging.project_backend.recruitment_board.domain.ActivityCategory;
 import mokindang.jubging.project_backend.recruitment_board.domain.RecruitmentBoard;
-import mokindang.jubging.project_backend.recruitment_board.domain.vo.*;
+import mokindang.jubging.project_backend.recruitment_board.domain.vo.ContentBody;
+import mokindang.jubging.project_backend.recruitment_board.domain.vo.ParticipationCount;
+import mokindang.jubging.project_backend.recruitment_board.domain.vo.StartingDate;
+import mokindang.jubging.project_backend.recruitment_board.domain.vo.Title;
 import mokindang.jubging.project_backend.recruitment_board.domain.vo.place.Coordinate;
 import mokindang.jubging.project_backend.recruitment_board.domain.vo.place.Place;
 import mokindang.jubging.project_backend.recruitment_board.service.response.board.SummaryBoardResponse;
@@ -28,7 +31,7 @@ class SummaryBoardResponseTest {
         RecruitmentBoard recruitmentBoard = createRecruitmentBoard();
 
         //when, then
-        assertThatCode(() -> new SummaryBoardResponse(recruitmentBoard)).doesNotThrowAnyException();
+        assertThatCode(() -> new SummaryBoardResponse(recruitmentBoard,1L)).doesNotThrowAnyException();
     }
 
     private RecruitmentBoard createRecruitmentBoard() {
@@ -51,7 +54,7 @@ class SummaryBoardResponseTest {
         //given
         SoftAssertions softly = new SoftAssertions();
         RecruitmentBoard recruitmentBoard = createMockedBoard();
-        SummaryBoardResponse summaryBoardResponse = new SummaryBoardResponse(recruitmentBoard);
+        SummaryBoardResponse summaryBoardResponse = new SummaryBoardResponse(recruitmentBoard,1L);
 
         //when
         Long boardId = summaryBoardResponse.getBoardId();


### PR DESCRIPTION
# Refactor/#413/요약 게시글 조회 api 리팩토링

### 이슈 번호 : #413 

## 변경 사항
-    기존에 있던 게시글(`RecruitmentBoard`, `CertificationBoard`)과 댓글 엔티티 사이의 연관관계 제거에 따른 변경
    - `RecruitmentBoard` 요약 게시글 조회 시, 댓글 카운트를 연관관계로 하던 것을 `commentRepository` 에 `count 쿼리`로 조회 후 넣어주도록 변경 

## 그 외
- 

## 질문 사항
- 
